### PR TITLE
fix: register hooks at register() time, not inside registerService.start() (fixes #4)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,21 @@ const otelObservabilityPlugin = {
     let telemetry: TelemetryRuntime | null = null;
     let unsubscribeDiagnostics: (() => void) | null = null;
 
+    // ── Init telemetry + hooks at top level ─────────────────────────
+    // MUST happen in register() (not inside registerService.start())
+    // because registerService is a no-op in embedded runner contexts.
+    // Hooks registered here will fire in both gateway and runner processes;
+    // hooks registered inside registerService.start() only fire in gateway.
+    // See: api-builder.ts noopRegisterService
+    try {
+      telemetry = initTelemetry(config, logger);
+      logger.info("[otel] Telemetry initialized in register() (universal context)");
+      registerHooks(api, telemetry, config);
+      logger.info("[otel] Hooks registered at top level (runner-compatible)");
+    } catch (err) {
+      logger.error(`[otel] Failed to initialize telemetry at register() time: ${err}`);
+    }
+
     // ── RPC: status endpoint ────────────────────────────────────────
 
     api.registerGatewayMethod(
@@ -105,30 +120,26 @@ const otelObservabilityPlugin = {
       id: "otel-observability",
 
       start: async () => {
-        logger.info("[otel] Starting OpenTelemetry observability...");
+        logger.info("[otel] Starting OpenTelemetry observability (gateway-only init)...");
 
-        // 1. Initialize our OTel providers FIRST (traces + metrics)
-        //    This registers our TracerProvider as global, so all spans
-        //    (including GenAI wraps) export through our pipeline.
-        telemetry = initTelemetry(config, logger);
+        // Telemetry + hooks were already initialized at register() time so
+        // they work in both gateway and runner contexts. Here we only do
+        // gateway-specific steps that don't need to run in the runner.
 
-        // 2. Wrap LLM SDKs AFTER provider is registered
-        //    The wraps use trace.getTracer() which goes through our provider.
+        // Gateway-only: OpenLLMetry SDK wrap detection (no-op without NODE_OPTIONS preload)
         if (config.traces) {
           await initOpenLLMetry(config, logger);
         }
 
-        // 3. Register hooks for tool results and command events
-        registerHooks(api, telemetry, config);
-
-        // 4. Subscribe to OpenClaw diagnostic events (model.usage, etc.)
-        //    This gives us cost data and accurate token counts
-        unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
-        if (hasDiagnosticsSupport()) {
-          logger.info("[otel] ✅ Integrated with OpenClaw diagnostics (cost tracking enabled)");
+        // Gateway-only: subscribe to diagnostic events (emitted from gateway process)
+        if (telemetry) {
+          unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
+          if (hasDiagnosticsSupport()) {
+            logger.info("[otel] ✅ Integrated with OpenClaw diagnostics (cost tracking enabled)");
+          }
         }
 
-        logger.info("[otel] ✅ Observability pipeline active");
+        logger.info("[otel] ✅ Observability pipeline active (gateway-side)");
         logger.info(
           `[otel]   Traces=${config.traces} Metrics=${config.metrics} Logs=${config.logs}`
         );


### PR DESCRIPTION
Fixes #4.

## Summary

Per-turn hooks (`before_agent_start`, `agent_end`, `tool_result_persist`, `message_received`) don't fire in OpenClaw's embedded runner contexts because the plugin registers them inside `api.registerService({ start: async () => { registerHooks(...) } })`. OC's plugin API wires `api.registerService` to a no-op handler in runner contexts (see openclaw/openclaw `src/plugins/api-builder.ts:56`), so the service's `start()` callback never runs, and hooks inside it never register.

Result: the plugin loads, all startup logs show "registered," but per-turn spans never fire for any agent turn that runs through the embedded runner (i.e. `openclaw agent` CLI, cron, heartbeat, task-runner, subagent — everything except channel auto-reply).

## Fix

Move `initTelemetry()` and `registerHooks()` from inside `registerService.start()` to the top level of `register()`. Both are safe to call at register-time:

- `initTelemetry()` in `src/telemetry.ts` is already synchronous
- `registerHooks()` takes the telemetry runtime as a parameter, which is now available immediately after `initTelemetry()`

The service's `start()` callback is retained for genuinely gateway-only work:
- `initOpenLLMetry()` — IITM preload detection only matters in the gateway process
- `registerDiagnosticsListener()` — `model.usage` events are emitted from the gateway process, so the listener only needs to live there

## What changed

`index.ts` — +27 lines, -16 lines. One file, commented inline with the reasoning.

## What did NOT change

- No changes to `src/*` modules
- No changes to hook handlers themselves
- No changes to the diagnostic listener
- No changes to the plugin configuration schema
- No changes to the span emission logic
- No changes to the service lifecycle (`stop()` unchanged)

## Empirical verification

Environment: OpenClaw v2026.4.2, Node v25.8.2, Arize Phoenix v14.1.1 self-hosted, otelcol-contrib v0.149.0 as the intermediary router.

**Before the fix:**
```
Phoenix total: 6 spans
     6 × openclaw.gateway.startup
```
Only the `gateway:startup` hook (registered via `api.registerHook`, a different API) fires. CLI agent turns produce NO per-turn spans. I verified with temporary `logger.info(HOOKFIRE ...)` promotion on hooks.ts:175 and :348 — zero hook firings in the gateway log during multiple CLI agent turns.

**After the fix:**
```
Phoenix total: 12 spans
     8 × openclaw.gateway.startup
     4 × openclaw.agent.turn
```

Fresh `openclaw.agent.turn` spans appear with full GenAI semconv attributes. Sample span from an Einstein CLI ping:

```json
{
  "name": "openclaw.agent.turn",
  "status_code": "OK",
  "attributes": {
    "openclaw.session.key": "agent:einstein:main",
    "openclaw.agent.id": "einstein",
    "openclaw.agent.duration_ms": 20850,
    "openclaw.agent.success": true,
    "gen_ai.response.model": "gpt-5.4",
    "gen_ai.usage.input_tokens": 52089,
    "gen_ai.usage.output_tokens": 9219,
    "gen_ai.usage.cache_read_tokens": 22016,
    "gen_ai.usage.total_tokens": 83324
  }
}
```

Also verified:
- Log sequence now shows two distinct `register()` invocations (main gateway process AND embedded runner), each producing the `[otel] Hooks registered at top level (runner-compatible)` log line
- No double-initialization — `initTelemetry()` runs once per context, same as the previous service-start path
- Gateway-only work (diagnostic listener, OpenLLMetry preload detection) still runs correctly in the gateway process
- Stop behavior unchanged (tested via `systemctl --user restart openclaw-gateway` — clean shutdown, `[otel] Telemetry shut down` visible)

## Typecheck

`npx tsc --noEmit` — exit 0, no errors.

## Context

This is separate from the per-LLM-call instrumentation limitation documented in `docs/limitations.md` (which is about pi-ai ESM/CJS interop with IITM preload). This PR addresses the hook-based per-turn observability path documented in `docs/architecture.md` Approach 2 — the intended use case for users who want connected traces without needing per-LLM-call granularity.

Happy to adjust the fix shape, add tests, or split the change further based on review feedback.