### PR TITLE
ISI-515: Fix hook registration timing — register hooks in register() not start()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,7 +59,9 @@ const otelObservabilityPlugin = {
     // registering them later inside service.start() means our listeners
     // are never seen by the gateway. We register here and pass a lazy
     // telemetry getter; hooks no-op until start() has built the runtime.
-    registerHooks(api, () => telemetry, config);
+    // registerHooks returns a cleanup fn (clears the stale-session sweeper
+    // interval) so service.stop() doesn't leak the timer across reloads.
+    let stopHooks: (() => void) | null = registerHooks(api, () => telemetry, config);
 
     // ── RPC: status endpoint ────────────────────────────────────────
 
@@ -142,6 +144,10 @@ const otelObservabilityPlugin = {
       },
 
       stop: async () => {
+        if (stopHooks) {
+          stopHooks();
+          stopHooks = null;
+        }
         if (unsubscribeDiagnostics) {
           unsubscribeDiagnostics();
           unsubscribeDiagnostics = null;

--- a/index.ts
+++ b/index.ts
@@ -54,6 +54,13 @@ const otelObservabilityPlugin = {
     let telemetry: TelemetryRuntime | null = null;
     let unsubscribeDiagnostics: (() => void) | null = null;
 
+    // ── Hooks (must be registered synchronously in register()) ──────
+    // OpenClaw snapshots typed hooks at plugin registration time, so
+    // registering them later inside service.start() means our listeners
+    // are never seen by the gateway. We register here and pass a lazy
+    // telemetry getter; hooks no-op until start() has built the runtime.
+    registerHooks(api, () => telemetry, config);
+
     // ── RPC: status endpoint ────────────────────────────────────────
 
     api.registerGatewayMethod(
@@ -118,11 +125,10 @@ const otelObservabilityPlugin = {
           await initOpenLLMetry(config, logger);
         }
 
-        // 3. Register hooks for tool results and command events
-        registerHooks(api, telemetry, config);
-
-        // 4. Subscribe to OpenClaw diagnostic events (model.usage, etc.)
-        //    This gives us cost data and accurate token counts
+        // 3. Subscribe to OpenClaw diagnostic events (model.usage, etc.)
+        //    This gives us cost data and accurate token counts.
+        //    (Hooks themselves are registered in register() above so they
+        //    are visible to the gateway before it finishes booting.)
         unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
         if (hasDiagnosticsSupport()) {
           logger.info("[otel] ✅ Integrated with OpenClaw diagnostics (cost tracking enabled)");

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -42,14 +42,26 @@ const sessionContextMap = new Map<string, SessionTraceContext>();
 
 /**
  * Register all plugin hooks on the OpenClaw plugin API.
+ *
+ * `getTelemetry` is a lazy accessor: this function runs during the synchronous
+ * `register()` phase so OpenClaw sees the typed hooks before the gateway boots,
+ * but the telemetry runtime is initialised later in `start()`. Each hook reads
+ * the current runtime when it fires; if telemetry is not ready yet (i.e. the
+ * hook fires between register() and start()) the handler is a no-op.
  */
 export function registerHooks(
   api: any,
-  telemetry: TelemetryRuntime,
+  getTelemetry: () => TelemetryRuntime | null,
   config: OtelObservabilityConfig
 ): void {
-  const { tracer, counters, histograms } = telemetry;
   const logger = api.logger;
+
+  const buildSecurityCounters = (counters: TelemetryRuntime["counters"]): SecurityCounters => ({
+    securityEvents: counters.securityEvents,
+    sensitiveFileAccess: counters.sensitiveFileAccess,
+    promptInjection: counters.promptInjection,
+    dangerousCommand: counters.dangerousCommand,
+  });
 
   // ═══════════════════════════════════════════════════════════════════
   // TYPED HOOKS — registered via api.on() into registry.typedHooks
@@ -59,17 +71,13 @@ export function registerHooks(
   // Creates the ROOT span for the entire request lifecycle.
   // All subsequent spans (agent, tools) become children of this span.
 
-  // Build security counters object for detection module
-  const securityCounters: SecurityCounters = {
-    securityEvents: counters.securityEvents,
-    sensitiveFileAccess: counters.sensitiveFileAccess,
-    promptInjection: counters.promptInjection,
-    dangerousCommand: counters.dangerousCommand,
-  };
-
   api.on(
     "message_received",
     async (event: any, ctx: any) => {
+      const telemetry = getTelemetry();
+      if (!telemetry) return;
+      const { tracer, counters } = telemetry;
+      const securityCounters = buildSecurityCounters(counters);
       try {
         const channel = event?.channel || "unknown";
         const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
@@ -130,6 +138,9 @@ export function registerHooks(
   api.on(
     "before_agent_start",
     (event: any, ctx: any) => {
+      const telemetry = getTelemetry();
+      if (!telemetry) return undefined;
+      const { tracer } = telemetry;
       try {
         const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
         const agentId = event?.agentId || ctx?.agentId || "unknown";
@@ -192,6 +203,10 @@ export function registerHooks(
   api.on(
     "tool_result_persist",
     (event: any, ctx: any) => {
+      const telemetry = getTelemetry();
+      if (!telemetry) return undefined;
+      const { tracer, counters } = telemetry;
+      const securityCounters = buildSecurityCounters(counters);
       try {
         const toolName = event?.toolName || "unknown";
         const toolCallId = event?.toolCallId || "";
@@ -293,6 +308,9 @@ export function registerHooks(
   api.on(
     "agent_end",
     async (event: any, ctx: any) => {
+      const telemetry = getTelemetry();
+      if (!telemetry) return;
+      const { counters, histograms } = telemetry;
       try {
         const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
         const agentId = event?.agentId || ctx?.agentId || "unknown";
@@ -447,6 +465,9 @@ export function registerHooks(
   api.registerHook(
     ["command:new", "command:reset", "command:stop"],
     async (event: any) => {
+      const telemetry = getTelemetry();
+      if (!telemetry) return;
+      const { tracer, counters } = telemetry;
       try {
         const action = event?.action || "unknown";
         const sessionKey = event?.sessionKey || "unknown";
@@ -493,6 +514,9 @@ export function registerHooks(
   api.registerHook(
     "gateway:startup",
     async (event: any) => {
+      const telemetry = getTelemetry();
+      if (!telemetry) return;
+      const { tracer } = telemetry;
       try {
         const span = tracer.startSpan("openclaw.gateway.startup", {
           kind: SpanKind.INTERNAL,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -53,7 +53,7 @@ export function registerHooks(
   api: any,
   getTelemetry: () => TelemetryRuntime | null,
   config: OtelObservabilityConfig
-): void {
+): () => void {
   const logger = api.logger;
 
   const buildSecurityCounters = (counters: TelemetryRuntime["counters"]): SecurityCounters => ({
@@ -540,8 +540,10 @@ export function registerHooks(
   logger.info("[otel] Registered gateway:startup hook (via api.registerHook)");
 
   // ── Periodic cleanup ─────────────────────────────────────────────
-  // Safety net: clean up stale session contexts (e.g., if agent_end never fires)
-  setInterval(() => {
+  // Safety net: clean up stale session contexts (e.g., if agent_end never fires).
+  // The handle is returned to the caller so service.stop() can clear it and
+  // avoid leaking timers across plugin reload / shutdown.
+  const cleanupInterval = setInterval(() => {
     const now = Date.now();
     const maxAge = 5 * 60 * 1000; // 5 minutes
     for (const [key, ctx] of sessionContextMap) {
@@ -555,4 +557,8 @@ export function registerHooks(
       }
     }
   }, 60_000);
+
+  return () => {
+    clearInterval(cleanupInterval);
+  };
 }


### PR DESCRIPTION
## Summary

All 15 plugin hooks were registered but never fired. Root cause: `registerHooks()` was called from inside `registerService.start()` (async, runs ~30s after the gateway is ready), while OpenClaw snapshots typed hooks at plugin **registration** time.

## Fix

- Move `registerHooks(api, getTelemetry, config)` into the synchronous `register()` phase in `index.ts` so the gateway sees the listeners before it boots.
- Change `registerHooks` in `src/hooks.ts` to take a lazy `getTelemetry: () => TelemetryRuntime | null` instead of the runtime directly, since telemetry is still initialised in `start()`.
- Each hook handler reads the live runtime when it fires and is a no-op until telemetry is ready (handles the brief window between `register()` and `start()`).

## Files

- `index.ts` — register hooks in `register()`, drop the call from `start()`
- `src/hooks.ts` — accept `getTelemetry` lazy getter, look up `tracer/counters/histograms` per call, build `securityCounters` per call

## Verification

- `tsc --noEmit` passes locally.

## Acceptance (per ISI-515)

- Hooks fire during message processing — look for `[otel] Root span started for session=...`, `[otel] Agent turn span started`, `[otel] Trace completed for session=...` in logs.
- Connected spans visible in Dynatrace: `openclaw.request` → `openclaw.agent.turn` → `tool.*`.

Paperclip ticket: ISI-515