### PR TITLE
ISI-521: Update README and mkdocs for hook-registration fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ For **deeper observability**, install the custom plugin from this repo. It uses 
 openclaw.request (root span)
 ├── openclaw.agent.turn
 │   ├── tool.Read (file read)
-│   ├── tool.exec (shell command)  
+│   ├── tool.exec (shell command)
 │   ├── tool.Write (file write)
 │   └── tool.web_search
 └── (child spans connected via trace context)
 ```
+
+Plus standalone spans on session commands (`openclaw.command.new|reset|stop`) and gateway startup (`openclaw.gateway.startup`).
 
 **Per-Tool Visibility:**
 - Individual spans for each tool call
@@ -91,6 +93,18 @@ openclaw.request (root span)
 - Full message → response tracing
 - Session context propagation
 - Agent turn duration with token breakdown
+
+### Plugin Lifecycle
+
+OpenClaw has two hook registration moments, and the plugin uses both at the right phase:
+
+| Phase | Runs | What the plugin does |
+|---|---|---|
+| `register()` | Synchronous, before the gateway accepts traffic | Registers **all 15 typed hooks** via `api.on()`, event-stream hooks (`command:*`, `gateway:startup`), the `otel-observability.status` RPC, the `otel` CLI command, the background service, and the optional `otel_status` agent tool. Hooks receive a **lazy telemetry getter** (`() => telemetry`) so they can be wired before the OTel runtime exists. |
+| `start()` | Async, after the gateway is ready | Calls `initTelemetry()` to build the `TracerProvider`/`MeterProvider` and register them globally, conditionally initializes OpenLLMetry wraps when `traces` is on, and subscribes to OpenClaw diagnostic events for cost/token data. |
+| `stop()` | Async, on gateway reload/shutdown | Clears the 60 s stale-session sweeper `setInterval` ([ISI-522](https://github.com/henrikrexed/openclaw-observability-plugin/commit/b668a4f)), unsubscribes from diagnostics, and calls `telemetry.shutdown()` to flush exporters. |
+
+**Why this matters:** OpenClaw snapshots typed hooks at registration time. If hooks are registered from `start()` instead of `register()`, the gateway never sees them and **hooks register but never fire**. PR #6 (see [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6)) moved them back to `register()` and introduced the lazy getter so handlers no-op cleanly during the brief `register()` → `start()` window.
 
 ### Installation
 
@@ -120,6 +134,38 @@ openclaw.request (root span)
    rm -rf /tmp/jiti
    systemctl --user restart openclaw-gateway
    ```
+
+### Validate your first trace
+
+Send a message that triggers at least one tool call and check Gateway logs for the lifecycle markers:
+
+```bash
+journalctl --user -u openclaw-gateway -f | grep -E '\[otel\]'
+```
+
+You should see, in this order:
+
+```
+[otel] Registered message_received hook (via api.on)
+[otel] Registered before_agent_start hook (via api.on)
+[otel] Registered tool_result_persist hook (via api.on)
+[otel] Registered agent_end hook (via api.on)
+[otel] Registered command event hooks (via api.registerHook)
+[otel] Registered gateway:startup hook (via api.registerHook)
+[otel] Starting OpenTelemetry observability...
+[otel] ✅ Observability pipeline active
+[otel]   Traces=true Metrics=true Logs=true
+[otel]   Endpoint=http://localhost:4318 (http)
+```
+
+Then, on the next inbound message, the debug log confirms hooks are live:
+
+```
+[otel] Root span started for session=<sessionKey>
+[otel] Agent turn span started: agent=<agentId>, session=<sessionKey>
+```
+
+In your backend, look for an `openclaw.request` span with at least one `openclaw.agent.turn` child. A healthy trace has `openclaw.request` → `openclaw.agent.turn` → one or more `tool.*` children.
 
 ---
 
@@ -283,6 +329,62 @@ Tetragon events are exported to `/var/log/tetragon/tetragon.log` and can be inge
 | **Kernel** | Tetragon | System calls, file access, network |
 
 See [Security: Tetragon](./docs/security/tetragon.md) for full installation and configuration guide.
+
+---
+
+## Troubleshooting
+
+### Hooks register but never fire
+
+**Symptom.** The plugin logs `[otel] ✅ Observability pipeline active` at gateway startup, but no `openclaw.request` or `tool.*` spans ever reach your backend — even after you send messages that clearly invoke tools.
+
+**Cause (pre-PR #6).** Earlier builds registered typed hooks from inside the async `service.start()` phase. OpenClaw snapshots typed hooks at plugin registration time, ~30 s before `start()` runs, so the gateway never saw the 15 hook listeners. See [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6).
+
+**Fix.** Upgrade to a build that includes PR #6. Hooks are now registered synchronously in `register()` and resolve the telemetry runtime lazily.
+
+**How to confirm hooks are live:**
+
+1. Check the gateway log for all six registration lines emitted from `register()`:
+   ```
+   [otel] Registered message_received hook (via api.on)
+   [otel] Registered before_agent_start hook (via api.on)
+   [otel] Registered tool_result_persist hook (via api.on)
+   [otel] Registered agent_end hook (via api.on)
+   [otel] Registered command event hooks (via api.registerHook)
+   [otel] Registered gateway:startup hook (via api.registerHook)
+   ```
+   If these are **missing**, the plugin is not loaded — check `plugins.load.paths` in `openclaw.json` and clear `/tmp/jiti`.
+
+2. Send a real message through the pipeline and watch for the per-event debug lines (enable debug logging first):
+   ```
+   [otel] Root span started for session=<sessionKey>
+   [otel] Agent turn span started: agent=<agentId>, session=<sessionKey>
+   ```
+   If registration lines are present but these do **not** appear on messages, the hooks are registered but the gateway is not firing them for your event path (e.g., heartbeats and some internal events do not carry full session context).
+
+3. Verify your OTLP endpoint is actually receiving data:
+   ```bash
+   curl -v http://localhost:4318/v1/traces
+   ```
+
+### Plugin not loaded at all
+
+Check plugin discovery:
+
+```bash
+openclaw plugins list
+```
+
+Clear the jiti cache and restart:
+
+```bash
+rm -rf /tmp/jiti
+systemctl --user restart openclaw-gateway
+```
+
+### Traces exported but not connected
+
+The custom plugin requires messages to flow through the normal pipeline (`message_received` → `before_agent_start` → tools → `agent_end`). Heartbeats and some internal events skip `message_received`, so those turns produce a standalone `openclaw.agent.turn` span without a parent `openclaw.request`. This is expected.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,70 @@ openclaw.session.stuck_age_ms
 
 ## Approach 2: Custom Hook-Based Plugin
 
+### Plugin Lifecycle
+
+OpenClaw drives plugins through three phases. Mixing them up is the single most common way to break the custom plugin — if typed hooks are registered in the wrong phase, the gateway never sees them and no spans are produced. The current layout:
+
+```
+┌──────────────┐      ┌──────────────┐      ┌──────────────┐
+│  register()  │ ───▶ │    start()   │ ───▶ │    stop()    │
+│  synchronous │      │     async    │      │     async    │
+└──────────────┘      └──────────────┘      └──────────────┘
+        │                     │                     │
+        │                     │                     │
+        ▼                     ▼                     ▼
+  - api.on(*)           - initTelemetry()    - stopHooks()
+  - api.registerHook()  - initOpenLLMetry()  - unsubscribe()
+  - api.registerGate…   - registerDiagnost… - telemetry.shutdown()
+  - api.registerCli()
+  - api.registerService()
+  - api.registerTool()
+        │                     │
+        └─── lazy getter ─────┘
+           () => telemetry
+```
+
+| Phase | Runs | Responsibility |
+|---|---|---|
+| `register()` | Synchronous, before the gateway accepts traffic | Wire every typed hook, event-stream hook, RPC method, CLI command, background service, and agent tool. All 15 typed hooks (`message_received`, `before_agent_start`, `tool_result_persist`, `agent_end`, plus the command and gateway event hooks) land here. |
+| `start()` | Async, once the gateway is ready | Build the OTel runtime (`initTelemetry` → TracerProvider + MeterProvider), optionally wrap LLM SDKs with OpenLLMetry when `traces` is on, and subscribe to OpenClaw diagnostic events for cost/token data. |
+| `stop()` | Async, on gateway reload or shutdown | Clear the stale-session sweeper `setInterval` (see [b668a4f](https://github.com/henrikrexed/openclaw-observability-plugin/commit/b668a4f), ISI-522), unsubscribe from diagnostics, and call `telemetry.shutdown()` so batched spans/metrics flush before the process exits. |
+
+### Lazy telemetry getter
+
+Hooks need to be registered in `register()` — which is synchronous and runs before `initTelemetry()` — but they need to read an OTel runtime that only exists after `start()`. The plugin solves this by registering hooks with a **lazy telemetry getter** instead of a concrete runtime:
+
+```typescript
+let telemetry: TelemetryRuntime | null = null;
+
+// Registered in register(), resolves telemetry at call time.
+let stopHooks = registerHooks(api, () => telemetry, config);
+
+api.registerService({
+  id: "otel-observability",
+  start: async () => {
+    telemetry = initTelemetry(config, logger);     // populated here
+    if (config.traces) await initOpenLLMetry(config, logger);
+    unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
+  },
+  stop: async () => {
+    stopHooks?.();                                  // clearInterval
+    unsubscribeDiagnostics?.();
+    await telemetry?.shutdown();
+    telemetry = null;
+  },
+});
+```
+
+Each hook handler opens with:
+
+```typescript
+const telemetry = getTelemetry();
+if (!telemetry) return;
+```
+
+so any hook that fires between `register()` and `start()` completing is a clean no-op. Once `initTelemetry()` runs, the next invocation sees a live runtime and begins emitting spans.
+
 ### How It Works
 
 The custom plugin uses **typed plugin hooks** — direct callbacks into the agent lifecycle.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -96,7 +96,40 @@ systemctl --user restart openclaw-gateway
 
 ### Step 5: Verify Connected Traces
 
-Send a message that triggers tool calls (e.g., "read my AGENTS.md file"). You should see:
+First, confirm the plugin is wired into the gateway. Tail the gateway log during startup:
+
+```bash
+journalctl --user -u openclaw-gateway -f | grep -E '\[otel\]'
+```
+
+You should see these lines **during `register()`** (before the gateway accepts traffic):
+
+```
+[otel] Registered message_received hook (via api.on)
+[otel] Registered before_agent_start hook (via api.on)
+[otel] Registered tool_result_persist hook (via api.on)
+[otel] Registered agent_end hook (via api.on)
+[otel] Registered command event hooks (via api.registerHook)
+[otel] Registered gateway:startup hook (via api.registerHook)
+```
+
+Then, **during `start()`** (after the gateway is ready):
+
+```
+[otel] Starting OpenTelemetry observability...
+[otel] ✅ Observability pipeline active
+[otel]   Traces=true Metrics=true Logs=true
+[otel]   Endpoint=http://localhost:4318 (http)
+```
+
+Now send a message that triggers tool calls (e.g., "read my AGENTS.md file"). On each inbound message, debug-level logs confirm hooks are firing:
+
+```
+[otel] Root span started for session=<sessionKey>
+[otel] Agent turn span started: agent=<agentId>, session=<sessionKey>
+```
+
+In your backend you should see a connected trace:
 
 ```
 openclaw.request
@@ -280,6 +313,41 @@ No collector needed:
 ### Traces not connected?
 
 The custom plugin requires messages to flow through the normal pipeline. Heartbeats and some internal events may not have full trace context.
+
+### Hooks register but never fire
+
+**Symptom:** Gateway logs `[otel] ✅ Observability pipeline active`, but no `openclaw.request` or `tool.*` spans reach your backend when you send messages.
+
+**Cause (pre-PR #6):** Earlier builds registered typed hooks from inside the async `service.start()` phase. OpenClaw snapshots typed hooks at plugin registration time — ~30 s before `start()` runs — so the gateway never saw the 15 hook listeners. Tracked as [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6).
+
+**Fix:** Upgrade to a build that includes PR #6. Hooks are now registered synchronously in `register()` and resolve the telemetry runtime through a lazy getter.
+
+**How to confirm hooks are live:**
+
+1. During gateway startup, look for all six registration lines from `register()`:
+   ```
+   [otel] Registered message_received hook (via api.on)
+   [otel] Registered before_agent_start hook (via api.on)
+   [otel] Registered tool_result_persist hook (via api.on)
+   [otel] Registered agent_end hook (via api.on)
+   [otel] Registered command event hooks (via api.registerHook)
+   [otel] Registered gateway:startup hook (via api.registerHook)
+   ```
+   If these are missing, the plugin is not loaded — recheck `plugins.load.paths` and clear `/tmp/jiti`.
+
+2. Send a real message through the pipeline and enable debug logging. You should see:
+   ```
+   [otel] Root span started for session=<sessionKey>
+   [otel] Agent turn span started: agent=<agentId>, session=<sessionKey>
+   ```
+   If registration lines are present but these are missing, the gateway is not firing hooks for that event path (e.g., heartbeats skip `message_received`).
+
+3. Verify the OTLP endpoint is reachable:
+   ```bash
+   curl -v http://localhost:4318/v1/traces
+   ```
+
+See [Architecture → Plugin Lifecycle](architecture.md#plugin-lifecycle) for why the `register()` vs `start()` split matters.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 1 doc refresh following the hook-registration fix (PR #6 / ISI-515) and the `setInterval` cleanup on `service.stop()` (commit b668a4f / ISI-522). A reader can now install the plugin, configure it, and validate their first trace without reading source.

## Changes

- **`README.md`**
  - New **Plugin Lifecycle** section covering the `register()` / `start()` / `stop()` phases, the lazy telemetry getter, and the stale-session sweeper cleanup.
  - New **Validate your first trace** section with the exact `[otel] ...` log lines in the order they appear during `register()` then `start()`, plus the per-message debug markers.
  - New **Troubleshooting** section with a dedicated entry for the original *"hooks register but never fire"* symptom — cause, fix, and three confirmation steps.
- **`docs/architecture.md`**
  - New **Plugin Lifecycle** and **Lazy telemetry getter** sections in the Custom Plugin chapter. Phase table + code sample showing how `registerHooks` is wired at `register()` time against a `() => telemetry` accessor that `start()` populates later, and how `stop()` clears the 60 s `setInterval`.
- **`docs/getting-started.md`**
  - Expanded **Verify Connected Traces** step with the six hook-registration log lines and the per-message debug markers.
  - Added a **Hooks register but never fire** troubleshooting entry with the cause, fix, and three confirmation steps, linking back to the architecture lifecycle section.

## Out of scope

Phase 2 — the per-span / per-attribute / per-metric semantic-convention reference table — is tracked separately on ISI-520 and will ship in a follow-up PR once the Observability Agent lands the semconv pass.

## Test plan

- [x] `mkdocs build --strict` — passes. (Two pre-existing INFO-level relative-link notices (`telemetry/`, `./backends/`) are unchanged by this PR.)
- [ ] Review rendered mkdocs site locally if preferred: `mkdocs serve`.
- [ ] Sanity-check the log lines in the README against a real gateway boot with the plugin loaded.

Refs: ISI-515, ISI-521, ISI-522. Unblocks ISI-520 Phase 2 doc extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via Paperclip
