### PR TITLE
ISI-520: align plugin telemetry with GenAI semantic conventions

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -9,6 +9,17 @@
 
 import type { Span } from "@opentelemetry/api";
 import type { TelemetryRuntime } from "./telemetry.js";
+import {
+  GEN_AI_CONVERSATION_ID,
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_RESPONSE_MODEL,
+  GEN_AI_SYSTEM,
+  GEN_AI_TOKEN_TYPE,
+  OP_INVOKE_AGENT,
+  OC_PROVIDER,
+  TOKEN_TYPE_INPUT,
+  TOKEN_TYPE_OUTPUT,
+} from "./semconv.js";
 
 // Import from OpenClaw plugin SDK (loaded lazily)
 let onDiagnosticEvent: ((listener: (evt: any) => void) => () => void) | null = null;
@@ -89,17 +100,29 @@ export async function registerDiagnosticsListener(
       model,
     });
 
-    // Record metrics immediately (don't wait for span)
+    // Record metrics immediately (don't wait for span).
+    // Use stable GenAI attribute keys; keep openclaw.* mirrors for dashboards.
     const metricAttrs = {
-      "gen_ai.response.model": model,
-      "openclaw.provider": provider,
+      [GEN_AI_RESPONSE_MODEL]: model,
+      [GEN_AI_SYSTEM]: provider,
+      [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
+      [GEN_AI_CONVERSATION_ID]: sessionKey,
+      [OC_PROVIDER]: provider,
     };
 
     if (usage.input) {
       counters.tokensPrompt.add(usage.input, metricAttrs);
+      histograms.genAiTokenUsage.record(usage.input, {
+        ...metricAttrs,
+        [GEN_AI_TOKEN_TYPE]: TOKEN_TYPE_INPUT,
+      });
     }
     if (usage.output) {
       counters.tokensCompletion.add(usage.output, metricAttrs);
+      histograms.genAiTokenUsage.record(usage.output, {
+        ...metricAttrs,
+        [GEN_AI_TOKEN_TYPE]: TOKEN_TYPE_OUTPUT,
+      });
     }
     if (usage.cacheRead) {
       counters.tokensPrompt.add(usage.cacheRead, { ...metricAttrs, "token.type": "cache_read" });
@@ -119,9 +142,10 @@ export async function registerDiagnosticsListener(
       }).add(costUsd, metricAttrs);
     }
 
-    // Record LLM duration
+    // Record LLM duration — legacy (ms) and stable GenAI (seconds).
     if (typeof evt.durationMs === "number") {
       histograms.llmDuration.record(evt.durationMs, metricAttrs);
+      histograms.genAiOperationDuration.record(evt.durationMs / 1000, metricAttrs);
     }
 
     counters.llmRequests.add(1, metricAttrs);

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -27,6 +27,30 @@ import type { TelemetryRuntime } from "./telemetry.js";
 import type { OtelObservabilityConfig } from "./config.js";
 import { activeAgentSpans, getPendingUsage, enrichSpanWithUsage, hasDiagnosticsSupport } from "./diagnostics.js";
 import { checkToolSecurity, checkMessageSecurity, type SecurityCounters } from "./security.js";
+import {
+  GEN_AI_AGENT_ID,
+  GEN_AI_AGENT_NAME,
+  GEN_AI_CONVERSATION_ID,
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_REQUEST_MODEL,
+  GEN_AI_RESPONSE_MODEL,
+  GEN_AI_SYSTEM,
+  GEN_AI_TOKEN_TYPE,
+  GEN_AI_TOOL_CALL_ID,
+  GEN_AI_TOOL_NAME,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+  OP_EXECUTE_TOOL,
+  OP_INVOKE_AGENT,
+  TOKEN_TYPE_INPUT,
+  TOKEN_TYPE_OUTPUT,
+  CODE_FUNCTION,
+  CODE_NAMESPACE,
+  ERROR_TYPE,
+  spanNameExecuteTool,
+} from "./semconv.js";
+
+const CODE_NS = "openclaw.otel.hooks";
 
 /** Active trace context for a session — allows connecting spans into one trace. */
 interface SessionTraceContext {
@@ -88,10 +112,16 @@ export function registerHooks(
         const rootSpan = tracer.startSpan("openclaw.request", {
           kind: SpanKind.SERVER,
           attributes: {
+            // openclaw legacy
             "openclaw.message.channel": channel,
             "openclaw.session.key": sessionKey,
             "openclaw.message.direction": "inbound",
             "openclaw.message.from": from,
+            // GenAI conversation correlation
+            [GEN_AI_CONVERSATION_ID]: sessionKey,
+            // code.*
+            [CODE_FUNCTION]: "message_received",
+            [CODE_NAMESPACE]: CODE_NS,
           },
         });
 
@@ -149,12 +179,24 @@ export function registerHooks(
         const sessionCtx = sessionContextMap.get(sessionKey);
         const parentContext = sessionCtx?.rootContext || context.active();
 
-        // Create agent turn span as child of root span
+        // Create agent turn span as child of root span.
+        // Name is kept as `openclaw.agent.turn` for dashboard backwards-compat;
+        // GenAI stable attributes below make it semconv-compliant.
         const agentSpan = tracer.startSpan(
           "openclaw.agent.turn",
           {
             kind: SpanKind.INTERNAL,
             attributes: {
+              // GenAI stable
+              [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
+              [GEN_AI_AGENT_ID]: agentId,
+              [GEN_AI_AGENT_NAME]: agentId,
+              [GEN_AI_CONVERSATION_ID]: sessionKey,
+              [GEN_AI_REQUEST_MODEL]: model,
+              // code.*
+              [CODE_FUNCTION]: "before_agent_start",
+              [CODE_NAMESPACE]: CODE_NS,
+              // openclaw legacy (preserve for dashboards)
               "openclaw.agent.id": agentId,
               "openclaw.session.key": sessionKey,
               "openclaw.agent.model": model,
@@ -217,8 +259,11 @@ export function registerHooks(
         // Tool input is available in event.input for security checks
         const toolInput = event?.input || event?.toolInput || event?.args || {};
 
-        // Record metric
+        // Record metric — use stable GenAI attribute keys, keep legacy mirrors.
         counters.toolCalls.add(1, {
+          [GEN_AI_TOOL_NAME]: toolName,
+          [GEN_AI_OPERATION_NAME]: OP_EXECUTE_TOOL,
+          [GEN_AI_CONVERSATION_ID]: sessionKey,
           "tool.name": toolName,
           "session.key": sessionKey,
         });
@@ -227,12 +272,23 @@ export function registerHooks(
         const sessionCtx = sessionContextMap.get(sessionKey);
         const parentContext = sessionCtx?.agentContext || sessionCtx?.rootContext || context.active();
 
-        // Create tool span as child of agent turn
+        // Create tool span as child of agent turn.
+        // Span name follows GenAI stable: `execute_tool {tool.name}`.
         const span = tracer.startSpan(
-          `tool.${toolName}`,
+          spanNameExecuteTool(toolName),
           {
             kind: SpanKind.INTERNAL,
             attributes: {
+              // GenAI stable
+              [GEN_AI_OPERATION_NAME]: OP_EXECUTE_TOOL,
+              [GEN_AI_TOOL_NAME]: toolName,
+              [GEN_AI_TOOL_CALL_ID]: toolCallId,
+              [GEN_AI_CONVERSATION_ID]: sessionKey,
+              [GEN_AI_AGENT_ID]: agentId,
+              // code.*
+              [CODE_FUNCTION]: "tool_result_persist",
+              [CODE_NAMESPACE]: CODE_NS,
+              // openclaw legacy (preserve for dashboards)
               "openclaw.tool.name": toolName,
               "openclaw.tool.call_id": toolCallId,
               "openclaw.tool.is_synthetic": isSynthetic,
@@ -275,7 +331,11 @@ export function registerHooks(
           }
 
           if (message?.is_error === true || message?.isError === true) {
-            counters.toolErrors.add(1, { "tool.name": toolName });
+            counters.toolErrors.add(1, {
+              [GEN_AI_TOOL_NAME]: toolName,
+              "tool.name": toolName,
+            });
+            span.setAttribute(ERROR_TYPE, "tool_execution_error");
             span.setStatus({ code: SpanStatusCode.ERROR, message: "Tool execution error" });
           } else if (!securityEvent) {
             // Only set OK status if no security event
@@ -407,26 +467,45 @@ export function registerHooks(
           // (diagnostics module already records metrics on model.usage event)
           if (!diagUsage && (totalInputTokens > 0 || totalOutputTokens > 0)) {
             const metricAttrs = {
-              "gen_ai.response.model": model,
+              [GEN_AI_RESPONSE_MODEL]: model,
+              [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
+              [GEN_AI_AGENT_ID]: agentId,
               "openclaw.agent.id": agentId,
             };
             counters.tokensPrompt.add(totalInputTokens + cacheReadTokens + cacheWriteTokens, metricAttrs);
             counters.tokensCompletion.add(totalOutputTokens, metricAttrs);
             counters.tokensTotal.add(totalTokens, metricAttrs);
             counters.llmRequests.add(1, metricAttrs);
-          }
 
-          // Record duration histogram
-          if (typeof durationMs === "number") {
-            histograms.agentTurnDuration.record(durationMs, {
-              "gen_ai.response.model": model,
-              "openclaw.agent.id": agentId,
+            // Stable GenAI token usage histogram (per gen_ai.token.type)
+            histograms.genAiTokenUsage.record(totalInputTokens + cacheReadTokens + cacheWriteTokens, {
+              ...metricAttrs,
+              [GEN_AI_TOKEN_TYPE]: TOKEN_TYPE_INPUT,
+            });
+            histograms.genAiTokenUsage.record(totalOutputTokens, {
+              ...metricAttrs,
+              [GEN_AI_TOKEN_TYPE]: TOKEN_TYPE_OUTPUT,
             });
           }
 
+          // Record duration histograms — legacy (ms) and stable GenAI (s).
+          if (typeof durationMs === "number") {
+            const durationAttrs = {
+              [GEN_AI_RESPONSE_MODEL]: model,
+              [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
+              [GEN_AI_AGENT_ID]: agentId,
+              "openclaw.agent.id": agentId,
+            };
+            histograms.agentTurnDuration.record(durationMs, durationAttrs);
+            histograms.genAiOperationDuration.record(durationMs / 1000, durationAttrs);
+          }
+
           if (errorMsg) {
-            agentSpan.setAttribute("openclaw.agent.error", String(errorMsg).slice(0, 500));
-            agentSpan.setStatus({ code: SpanStatusCode.ERROR, message: String(errorMsg).slice(0, 200) });
+            const errStr = String(errorMsg).slice(0, 500);
+            agentSpan.setAttribute("openclaw.agent.error", errStr);
+            agentSpan.setAttribute(ERROR_TYPE, "agent_error");
+            agentSpan.recordException({ name: "AgentError", message: errStr });
+            agentSpan.setStatus({ code: SpanStatusCode.ERROR, message: errStr.slice(0, 200) });
           } else {
             agentSpan.setStatus({ code: SpanStatusCode.OK });
           }

--- a/src/semconv.ts
+++ b/src/semconv.ts
@@ -1,0 +1,90 @@
+/**
+ * OpenTelemetry attribute keys used by this plugin.
+ *
+ * Centralised so the same constant is referenced on spans, metrics, and docs,
+ * and so a future Weaver-generated schema can replace this file without
+ * touching every call site.
+ *
+ * References:
+ *   - gen_ai.* stable conventions (GenAI agents / tools / tokens)
+ *   - exception.* / error.type (general conventions)
+ *   - code.* (general conventions)
+ *   - openclaw.* keys are plugin-domain attributes not covered by OTel semconv;
+ *     they are kept as legacy mirrors alongside the standard gen_ai.* keys to
+ *     preserve existing Dynatrace dashboards during the rollout window.
+ */
+
+// ── GenAI stable attribute keys ─────────────────────────────────────
+export const GEN_AI_SYSTEM = "gen_ai.system";
+export const GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
+export const GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
+export const GEN_AI_RESPONSE_MODEL = "gen_ai.response.model";
+export const GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id";
+export const GEN_AI_AGENT_ID = "gen_ai.agent.id";
+export const GEN_AI_AGENT_NAME = "gen_ai.agent.name";
+export const GEN_AI_TOOL_NAME = "gen_ai.tool.name";
+export const GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id";
+export const GEN_AI_TOOL_TYPE = "gen_ai.tool.type";
+export const GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
+export const GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
+export const GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens";
+/** Non-stable but de-facto — cache tokens are not yet covered by stable semconv. */
+export const GEN_AI_USAGE_CACHE_READ_TOKENS = "gen_ai.usage.cache_read_tokens";
+export const GEN_AI_USAGE_CACHE_WRITE_TOKENS = "gen_ai.usage.cache_write_tokens";
+/** Used on `gen_ai.client.token.usage` histogram to distinguish input / output. */
+export const GEN_AI_TOKEN_TYPE = "gen_ai.token.type";
+
+// ── GenAI operation name values ─────────────────────────────────────
+export const OP_INVOKE_AGENT = "invoke_agent";
+export const OP_EXECUTE_TOOL = "execute_tool";
+export const OP_CHAT = "chat";
+
+// ── GenAI stable metric names ───────────────────────────────────────
+export const METRIC_TOKEN_USAGE = "gen_ai.client.token.usage";
+export const METRIC_OPERATION_DURATION = "gen_ai.client.operation.duration";
+
+// ── GenAI span name helpers ─────────────────────────────────────────
+export const spanNameInvokeAgent = (agentName: string): string =>
+  `${OP_INVOKE_AGENT} ${agentName}`;
+export const spanNameExecuteTool = (toolName: string): string =>
+  `${OP_EXECUTE_TOOL} ${toolName}`;
+
+// ── Error / exception conventions ───────────────────────────────────
+export const ERROR_TYPE = "error.type";
+
+// ── Code conventions ────────────────────────────────────────────────
+export const CODE_FUNCTION = "code.function";
+export const CODE_NAMESPACE = "code.namespace";
+
+// ── Plugin-domain (legacy) attribute keys ───────────────────────────
+export const OC_AGENT_ID = "openclaw.agent.id";
+export const OC_AGENT_MODEL = "openclaw.agent.model";
+export const OC_AGENT_DURATION_MS = "openclaw.agent.duration_ms";
+export const OC_AGENT_SUCCESS = "openclaw.agent.success";
+export const OC_AGENT_ERROR = "openclaw.agent.error";
+export const OC_SESSION_KEY = "openclaw.session.key";
+export const OC_TOOL_NAME = "openclaw.tool.name";
+export const OC_TOOL_CALL_ID = "openclaw.tool.call_id";
+export const OC_TOOL_IS_SYNTHETIC = "openclaw.tool.is_synthetic";
+export const OC_TOOL_RESULT_CHARS = "openclaw.tool.result_chars";
+export const OC_TOOL_RESULT_PARTS = "openclaw.tool.result_parts";
+export const OC_TOOL_INPUT_PREVIEW = "openclaw.tool.input_preview";
+export const OC_MESSAGE_CHANNEL = "openclaw.message.channel";
+export const OC_MESSAGE_DIRECTION = "openclaw.message.direction";
+export const OC_MESSAGE_FROM = "openclaw.message.from";
+export const OC_REQUEST_DURATION_MS = "openclaw.request.duration_ms";
+export const OC_LLM_COST_USD = "openclaw.llm.cost_usd";
+export const OC_CONTEXT_LIMIT = "openclaw.context.limit";
+export const OC_CONTEXT_USED = "openclaw.context.used";
+export const OC_PROVIDER = "openclaw.provider";
+export const OC_SCHEMA_VERSION = "openclaw.schema.version";
+
+/**
+ * Schema version for plugin-domain attributes. Bump when emitted
+ * attribute keys or values change in a way that consumers need to know.
+ */
+export const OPENCLAW_SCHEMA_VERSION = "1.0.0";
+
+// ── Token type values ───────────────────────────────────────────────
+export const TOKEN_TYPE_INPUT = "input";
+export const TOKEN_TYPE_OUTPUT = "output";

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -21,6 +21,12 @@ import { OTLPMetricExporter as OTLPMetricExporterHTTP } from "@opentelemetry/exp
 import { OTLPMetricExporter as OTLPMetricExporterGRPC } from "@opentelemetry/exporter-metrics-otlp-grpc";
 
 import type { OtelObservabilityConfig } from "./config.js";
+import {
+  METRIC_OPERATION_DURATION,
+  METRIC_TOKEN_USAGE,
+  OC_SCHEMA_VERSION,
+  OPENCLAW_SCHEMA_VERSION,
+} from "./semconv.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -71,6 +77,10 @@ export interface OtelHistograms {
   toolDuration: Histogram;
   /** Agent turn duration in ms */
   agentTurnDuration: Histogram;
+  /** Stable GenAI client operation duration (seconds). */
+  genAiOperationDuration: Histogram;
+  /** Stable GenAI client token usage (tokens); use with gen_ai.token.type attr. */
+  genAiTokenUsage: Histogram;
 }
 
 export interface OtelGauges {
@@ -85,6 +95,7 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
     [ATTR_SERVICE_NAME]: config.serviceName,
     [ATTR_SERVICE_VERSION]: "0.1.0",
     "openclaw.plugin": "otel-observability",
+    [OC_SCHEMA_VERSION]: OPENCLAW_SCHEMA_VERSION,
     ...config.resourceAttributes,
   };
 
@@ -223,6 +234,14 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
     agentTurnDuration: meter.createHistogram("openclaw.agent.turn_duration", {
       description: "Full agent turn duration (LLM + tools)",
       unit: "ms",
+    }),
+    genAiOperationDuration: meter.createHistogram(METRIC_OPERATION_DURATION, {
+      description: "GenAI operation duration (stable semconv)",
+      unit: "s",
+    }),
+    genAiTokenUsage: meter.createHistogram(METRIC_TOKEN_USAGE, {
+      description: "Number of input and output tokens used (stable semconv)",
+      unit: "{token}",
     }),
   };
 


### PR DESCRIPTION
## Summary
Aligns the plugin's emitted spans, metrics, and resource attributes with the stable OpenTelemetry GenAI semantic conventions without breaking existing Dynatrace dashboards.

Based on the audit in ISI-520 (Paperclip): https://github.com/henrikrexed/openclaw-observability-plugin — full mapping lives in the Paperclip plan document.

### Spans
- **Agent turn** (`openclaw.agent.turn`) now carries:
  - `gen_ai.operation.name = invoke_agent`
  - `gen_ai.agent.id` / `gen_ai.agent.name`
  - `gen_ai.conversation.id` (mirrors `openclaw.session.key`)
  - `gen_ai.request.model` (+ existing `gen_ai.response.model`)
- **Tool span** is now `execute_tool {tool.name}` with:
  - `gen_ai.operation.name = execute_tool`
  - `gen_ai.tool.name`
  - `gen_ai.tool.call.id`
  - `gen_ai.conversation.id`, `gen_ai.agent.id`
- **Root request span** (`openclaw.request`) gains `gen_ai.conversation.id` and `code.*` attributes.
- **Error paths** now set `error.type` and call `span.recordException()`.
- All plugin spans carry `code.function` / `code.namespace` identifying the hook handler.

### Metrics
- Two new stable-semconv histograms:
  - `gen_ai.client.token.usage` (unit `{token}`) with `gen_ai.token.type = input|output`.
  - `gen_ai.client.operation.duration` (unit `s`).
- Existing `openclaw.*` counters + histograms are kept untouched for dashboard backwards-compat.
- Tool-call metric attributes gained `gen_ai.tool.name`, `gen_ai.operation.name`, and `gen_ai.conversation.id` alongside the legacy `tool.name` / `session.key`.

### Resource
- New `openclaw.schema.version = 1.0.0` on the resource so downstream consumers can version-gate.

### Code organisation
- New `src/semconv.ts` centralises every attribute key and span-name helper — a future Weaver-generated module can replace it without touching call sites.

## Non-goals
- No span rename for `openclaw.agent.turn` (keeps dashboards intact; the GenAI attributes make it compliant).
- No deletion of legacy `openclaw.*` keys — a follow-up PR can retire them once downstream dashboards have migrated.
- Weaver-based semconv lint is not wired up yet (recommended follow-up story).

## Test plan
- [x] `npm run typecheck` passes locally.
- [ ] Smoke test against the Dynatrace tenant from ISI-516 once this PR is deployed: confirm the `openclaw.request → openclaw.agent.turn → execute_tool {name}` hierarchy and that `gen_ai.*` attributes are searchable.
- [ ] Content Writer hand-off (ISI-521) to reflect the new attributes in the docs.

## Coordination
- Branched from `main` after PR #6 / ISI-515 merged, per the ISI-520 task description.