### PR TITLE
ISI-526: Align README license with Apache-2.0 (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenClaw Observability
 
 [![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://henrikrexed.github.io/openclaw-observability-plugin/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 OpenTelemetry observability for [OpenClaw](https://github.com/openclaw/openclaw) AI agents.
 
@@ -400,4 +400,4 @@ See [Limitations](./docs/limitations.md) for details.
 
 ## License
 
-MIT
+Apache License 2.0 — see [LICENSE](./LICENSE) for the full text.


### PR DESCRIPTION
## Summary
- README badge and `## License` section claimed MIT, but the repo LICENSE file and `package.json` both declare Apache-2.0.
- Update the badge and the license section in README.md so the project is consistently Apache-2.0.
- No license references exist in `mkdocs.yml` or the `docs/` tree, so nothing else needed updating.

Closes #3.

Tracked in Paperclip issue ISI-526.

## Test plan
- [x] `git diff` shows only README.md changes (badge + `## License` body).
- [x] `LICENSE` (Apache 2.0) and `package.json` (`"license": "Apache-2.0"`) are unchanged and already agree.
- [ ] Render the README on GitHub after merge and confirm the badge points to the Apache 2.0 page.