### PR TITLE
ISI-529: init telemetry in register() for runner-context span emission

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -53,15 +53,27 @@ const otelObservabilityPlugin = {
 
     let telemetry: TelemetryRuntime | null = null;
     let unsubscribeDiagnostics: (() => void) | null = null;
+    let stopHooks: (() => void) | null = null;
 
-    // ── Hooks (must be registered synchronously in register()) ──────
-    // OpenClaw snapshots typed hooks at plugin registration time, so
-    // registering them later inside service.start() means our listeners
-    // are never seen by the gateway. We register here and pass a lazy
-    // telemetry getter; hooks no-op until start() has built the runtime.
-    // registerHooks returns a cleanup fn (clears the stale-session sweeper
-    // interval) so service.stop() doesn't leak the timer across reloads.
-    let stopHooks: (() => void) | null = registerHooks(api, () => telemetry, config);
+    // ── Telemetry + hooks (init at register() time) ─────────────────
+    // Both MUST run during register() so they work in every OpenClaw
+    // context, not just the gateway:
+    //   - Hooks: OpenClaw snapshots typed hooks at plugin registration,
+    //     so registering later means the gateway never sees them.
+    //   - Telemetry: api.registerService.start() is a no-op in embedded
+    //     runner contexts (openclaw agent CLI, cron, heartbeat,
+    //     task-runner, subagent — see openclaw src/plugins/api-builder.ts).
+    //     Initializing inside start() means telemetry stays null in
+    //     those contexts and every hook is a no-op.
+    // registerHooks returns a cleanup fn (clears the stale-session
+    // sweeper interval) so service.stop() doesn't leak the timer.
+    try {
+      telemetry = initTelemetry(config, logger);
+      stopHooks = registerHooks(api, telemetry, config);
+      logger.info("[otel] Telemetry + hooks initialized at register() (runner-compatible)");
+    } catch (err) {
+      logger.error(`[otel] Failed to initialize telemetry at register() time: ${String(err)}`);
+    }
 
     // ── RPC: status endpoint ────────────────────────────────────────
 
@@ -114,29 +126,32 @@ const otelObservabilityPlugin = {
       id: "otel-observability",
 
       start: async () => {
-        logger.info("[otel] Starting OpenTelemetry observability...");
+        logger.info("[otel] Starting OpenTelemetry observability (gateway-only init)...");
 
-        // 1. Initialize our OTel providers FIRST (traces + metrics)
-        //    This registers our TracerProvider as global, so all spans
-        //    (including GenAI wraps) export through our pipeline.
-        telemetry = initTelemetry(config, logger);
+        // Telemetry + hooks are already initialized at register() time so
+        // they work in both gateway and embedded runner contexts. Only
+        // gateway-specific work lives here.
 
-        // 2. Wrap LLM SDKs AFTER provider is registered
-        //    The wraps use trace.getTracer() which goes through our provider.
+        // 1. Wrap LLM SDKs. The wraps use trace.getTracer() which goes
+        //    through the provider we registered above. OpenLLMetry's
+        //    IITM preload only matters in the long-running gateway
+        //    process, so leave it here.
         if (config.traces) {
           await initOpenLLMetry(config, logger);
         }
 
-        // 3. Subscribe to OpenClaw diagnostic events (model.usage, etc.)
-        //    This gives us cost data and accurate token counts.
-        //    (Hooks themselves are registered in register() above so they
-        //    are visible to the gateway before it finishes booting.)
-        unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
-        if (hasDiagnosticsSupport()) {
-          logger.info("[otel] ✅ Integrated with OpenClaw diagnostics (cost tracking enabled)");
+        // 2. Subscribe to OpenClaw diagnostic events (model.usage, etc.)
+        //    for cost + accurate token counts. These events are emitted
+        //    from the gateway process, so the listener only needs to
+        //    live there.
+        if (telemetry) {
+          unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
+          if (hasDiagnosticsSupport()) {
+            logger.info("[otel] ✅ Integrated with OpenClaw diagnostics (cost tracking enabled)");
+          }
         }
 
-        logger.info("[otel] ✅ Observability pipeline active");
+        logger.info("[otel] ✅ Observability pipeline active (gateway-side)");
         logger.info(
           `[otel]   Traces=${config.traces} Metrics=${config.metrics} Logs=${config.logs}`
         );

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -67,25 +67,25 @@ const sessionContextMap = new Map<string, SessionTraceContext>();
 /**
  * Register all plugin hooks on the OpenClaw plugin API.
  *
- * `getTelemetry` is a lazy accessor: this function runs during the synchronous
- * `register()` phase so OpenClaw sees the typed hooks before the gateway boots,
- * but the telemetry runtime is initialised later in `start()`. Each hook reads
- * the current runtime when it fires; if telemetry is not ready yet (i.e. the
- * hook fires between register() and start()) the handler is a no-op.
+ * Both `initTelemetry()` and this function run during the synchronous
+ * `register()` phase so OpenClaw sees the typed hooks before the gateway
+ * boots AND so telemetry exists in embedded runner contexts (CLI agent,
+ * cron, heartbeat, task-runner, subagent) where `service.start()` is a
+ * no-op. The telemetry runtime is therefore non-null at hook-fire time.
  */
 export function registerHooks(
   api: any,
-  getTelemetry: () => TelemetryRuntime | null,
+  telemetry: TelemetryRuntime,
   config: OtelObservabilityConfig
 ): () => void {
   const logger = api.logger;
-
-  const buildSecurityCounters = (counters: TelemetryRuntime["counters"]): SecurityCounters => ({
+  const { tracer, counters, histograms } = telemetry;
+  const securityCounters: SecurityCounters = {
     securityEvents: counters.securityEvents,
     sensitiveFileAccess: counters.sensitiveFileAccess,
     promptInjection: counters.promptInjection,
     dangerousCommand: counters.dangerousCommand,
-  });
+  };
 
   // ═══════════════════════════════════════════════════════════════════
   // TYPED HOOKS — registered via api.on() into registry.typedHooks
@@ -98,10 +98,6 @@ export function registerHooks(
   api.on(
     "message_received",
     async (event: any, ctx: any) => {
-      const telemetry = getTelemetry();
-      if (!telemetry) return;
-      const { tracer, counters } = telemetry;
-      const securityCounters = buildSecurityCounters(counters);
       try {
         const channel = event?.channel || "unknown";
         const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
@@ -168,9 +164,6 @@ export function registerHooks(
   api.on(
     "before_agent_start",
     (event: any, ctx: any) => {
-      const telemetry = getTelemetry();
-      if (!telemetry) return undefined;
-      const { tracer } = telemetry;
       try {
         const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
         const agentId = event?.agentId || ctx?.agentId || "unknown";
@@ -245,10 +238,6 @@ export function registerHooks(
   api.on(
     "tool_result_persist",
     (event: any, ctx: any) => {
-      const telemetry = getTelemetry();
-      if (!telemetry) return undefined;
-      const { tracer, counters } = telemetry;
-      const securityCounters = buildSecurityCounters(counters);
       try {
         const toolName = event?.toolName || "unknown";
         const toolCallId = event?.toolCallId || "";
@@ -368,9 +357,6 @@ export function registerHooks(
   api.on(
     "agent_end",
     async (event: any, ctx: any) => {
-      const telemetry = getTelemetry();
-      if (!telemetry) return;
-      const { counters, histograms } = telemetry;
       try {
         const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
         const agentId = event?.agentId || ctx?.agentId || "unknown";
@@ -544,9 +530,6 @@ export function registerHooks(
   api.registerHook(
     ["command:new", "command:reset", "command:stop"],
     async (event: any) => {
-      const telemetry = getTelemetry();
-      if (!telemetry) return;
-      const { tracer, counters } = telemetry;
       try {
         const action = event?.action || "unknown";
         const sessionKey = event?.sessionKey || "unknown";
@@ -593,9 +576,6 @@ export function registerHooks(
   api.registerHook(
     "gateway:startup",
     async (event: any) => {
-      const telemetry = getTelemetry();
-      if (!telemetry) return;
-      const { tracer } = telemetry;
       try {
         const span = tracer.startSpan("openclaw.gateway.startup", {
           kind: SpanKind.INTERNAL,


### PR DESCRIPTION
## Summary

Follow-up to ISI-515. Per-turn hooks register correctly now, but in OpenClaw's **embedded runner contexts** (`openclaw agent` CLI, cron, heartbeat, task-runner, subagent) the telemetry runtime never gets built, so every hook fires as a no-op and no `openclaw.agent.turn` spans are emitted.

## Why

`api.registerService.start()` is only invoked from the gateway's `startPluginServices` call in `openclaw/openclaw src/gateway/server-startup.ts:155`. Runner contexts call `loadOpenClawPlugins()` (which runs each plugin's `register()`) but never call `startPluginServices()` — the service's `start()` callback is effectively a no-op off the gateway path. Since ISI-515 moved hook registration into `register()` while leaving `initTelemetry()` inside `start()`, the hooks are there but `telemetry` stays `null` forever in runners.

@Kaspre independently caught this in [#5](https://github.com/henrikrexed/openclaw-observability-plugin/pull/5) with empirical verification: before the fix, 0 × `openclaw.agent.turn` spans across multiple CLI agent turns; after, 4 × turn spans with full GenAI attributes.

## Fix

- Move `initTelemetry()` out of `service.start()` and call it at `register()` time, right before `registerHooks()`. Both now run in every context.
- Change `registerHooks(api, getTelemetry, config)` → `registerHooks(api, telemetry, config)`. Telemetry is guaranteed non-null at hook-fire time, so the lazy getter and per-hook `if (!telemetry) return` guards are removed.
- Keep `service.start()` for genuinely gateway-only work:
  - `initOpenLLMetry()` (IITM preload detection only matters in the long-running gateway process)
  - `registerDiagnosticsListener()` (`model.usage` events are emitted from the gateway)

## Test plan

- [x] `tsc --noEmit` — clean
- [ ] Reviewer sanity-check: run `openclaw agent` turn with this branch installed, confirm `openclaw.agent.turn` spans appear in Phoenix / OTLP backend (matches Kaspre's empirical test in #5)
- [ ] Confirm gateway-side behavior is unchanged (`gateway:startup` span still fires, diagnostic listener still attaches)

Fixes ISI-529. Closes #4. Supersedes #5 with the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)