### PR TITLE
ISI-730: migrate off legacy before_agent_start hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,69 @@
 # Changelog
 
-All notable changes to the OpenClaw OTel Observability Plugin are documented here.
+All notable changes to the `@openclaw/otel-observability` plugin are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] — 2026-04-23
 
 ### Changed
 
-- **`captureContent` is now wired end-to-end to Traceloop LLM-client spans.** Setting `captureContent: true` in the plugin config (plus `OPENCLAW_OTEL_CAPTURE_CONTENT=true` in the gateway's environment, read by `instrumentation/preload.mjs` before Traceloop loads) causes `@traceloop/instrumentation-anthropic` and `@traceloop/instrumentation-openai` to record prompt and completion text as `gen_ai.prompt.*` / `gen_ai.completion.*` span attributes. Previously the option was accepted but had no effect on LLM-client spans.
+- **Hook migration (ISI-730).** Replaced the legacy `before_agent_start` hook
+  registration with the phase-specific hooks introduced in OpenClaw 2026.2:
+  - `before_model_resolve` — creates the `openclaw.agent.turn` span at the
+    earliest point in the agent run. Agent-identity attributes
+    (`gen_ai.agent.id`, `gen_ai.conversation.id`, `openclaw.agent.id`,
+    `openclaw.session.key`) are set here. `gen_ai.request.model` is
+    intentionally omitted because the model has not yet been resolved.
+  - `before_prompt_build` — enriches the existing agent turn span with
+    `openclaw.prompt.chars` and `openclaw.session.message_count` once the
+    session history has been loaded, before the LLM call.
+
+  Existing trace structure (`openclaw.request` → `openclaw.agent.turn` →
+  tool spans → `agent_end`) is preserved. All previously-emitted span
+  attributes still appear on the agent turn span; two new
+  `openclaw.prompt.*` / `openclaw.session.message_count` attributes are
+  added as a bonus.
+
+- **`captureContent` is now wired end-to-end to Traceloop LLM-client spans
+  (ISI-733).** Setting `captureContent: true` in the plugin config (plus
+  `OPENCLAW_OTEL_CAPTURE_CONTENT=true` in the gateway's environment, read by
+  `instrumentation/preload.mjs` before Traceloop loads) causes
+  `@traceloop/instrumentation-anthropic` and
+  `@traceloop/instrumentation-openai` to record prompt and completion text
+  as `gen_ai.prompt.*` / `gen_ai.completion.*` span attributes. Previously
+  the option was accepted but had no effect on LLM-client spans.
   - Default stays `false` (privacy-first).
-  - `captureContent` is a **gateway-launch setting, not hot-reloadable** — the preload runs before plugin config is parsed, so the Traceloop instrumentations are constructed once at process start. Restart the gateway to pick up changes.
-  - The plugin logs a warning at `start()` if the config and the preload's resolved env-var value disagree.
-  - See [docs/security/privacy.md](docs/security/privacy.md) and [docs/configuration.md](docs/configuration.md#capturecontent-gateway-launch-setting).
-  - Resolves [github issue #15](https://github.com/henrikrexed/openclaw-observability-plugin/issues/15) (ISI-733 / ISI-734).
+  - `captureContent` is a **gateway-launch setting, not hot-reloadable** —
+    the preload runs before plugin config is parsed, so the Traceloop
+    instrumentations are constructed once at process start. Restart the
+    gateway to pick up changes.
+  - The plugin logs a warning at `start()` if the config and the preload's
+    resolved env-var value disagree.
+  - See [docs/security/privacy.md](docs/security/privacy.md) and
+    [docs/configuration.md](docs/configuration.md#capturecontent-gateway-launch-setting).
+  - Resolves [github issue #15](https://github.com/henrikrexed/openclaw-observability-plugin/issues/15)
+    (ISI-733 / ISI-734).
+
+### Removed
+
+- `before_agent_start` hook registration. The plugin no longer listens to
+  this legacy hook. If you run this version against OpenClaw &lt; 2026.2,
+  the agent turn span will not be created. Pin to `0.1.x` if you still
+  need the legacy path.
 
 ### Added
 
-- `instrumentation/capture-content.mjs` exports `resolveCaptureContent(env)` and the `CAPTURE_CONTENT_ENV` constant, consumed by the preload and covered by `instrumentation/capture-content.test.mjs` (`npm test`, uses `node --test`).
-- `docs/security/privacy.md` — new page covering the privacy implications of `captureContent`, how to enable it safely, and redaction guidance.
+- `minOpenClawVersion: 2026.2.0` in `openclaw.plugin.json`.
+- Regression tests for hook wiring (`tests/hooks.test.ts`).
+- `instrumentation/capture-content.mjs` exports `resolveCaptureContent(env)`
+  and the `CAPTURE_CONTENT_ENV` constant, consumed by the preload and
+  covered by `instrumentation/capture-content.test.mjs` (`npm test`, uses
+  `node --test`).
+- `docs/security/privacy.md` — new page covering the privacy implications
+  of `captureContent`, how to enable it safely, and redaction guidance.
+
+## [0.1.0] — 2026-04-16
+
+Initial public release. See the repository `README.md` and `docs/` tree for
+capability documentation.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ You should see, in this order:
 
 ```
 [otel] Registered message_received hook (via api.on)
-[otel] Registered before_agent_start hook (via api.on)
+[otel] Registered before_model_resolve hook (via api.on)
+[otel] Registered before_prompt_build hook (via api.on)
 [otel] Registered tool_result_persist hook (via api.on)
 [otel] Registered agent_end hook (via api.on)
 [otel] Registered command event hooks (via api.registerHook)
@@ -168,6 +169,11 @@ You should see, in this order:
 [otel]   Traces=true Metrics=true Logs=true
 [otel]   Endpoint=http://localhost:4318 (http)
 ```
+
+> **Hook migration (v0.2.0, ISI-730).** The plugin migrated off the legacy
+> `before_agent_start` hook. The agent turn span is now started in
+> `before_model_resolve` and enriched in `before_prompt_build`. This requires
+> OpenClaw ≥ 2026.2. Pin to `0.1.x` if you need the legacy path.
 
 Then, on the next inbound message, the debug log confirms hooks are live:
 
@@ -376,10 +382,11 @@ See [Security: Tetragon](./docs/security/tetragon.md) for full installation and 
 
 **How to confirm hooks are live:**
 
-1. Check the gateway log for all six registration lines emitted from `register()`:
+1. Check the gateway log for the registration lines emitted from `register()`:
    ```
    [otel] Registered message_received hook (via api.on)
-   [otel] Registered before_agent_start hook (via api.on)
+   [otel] Registered before_model_resolve hook (via api.on)
+   [otel] Registered before_prompt_build hook (via api.on)
    [otel] Registered tool_result_persist hook (via api.on)
    [otel] Registered agent_end hook (via api.on)
    [otel] Registered command event hooks (via api.registerHook)
@@ -416,7 +423,7 @@ systemctl --user restart openclaw-gateway
 
 ### Traces exported but not connected
 
-The custom plugin requires messages to flow through the normal pipeline (`message_received` → `before_agent_start` → tools → `agent_end`). Heartbeats and some internal events skip `message_received`, so those turns produce a standalone `openclaw.agent.turn` span without a parent `openclaw.request`. This is expected.
+The custom plugin requires messages to flow through the normal pipeline (`message_received` → `before_model_resolve` → `before_prompt_build` → tools → `agent_end`). Heartbeats and some internal events skip `message_received`, so those turns produce a standalone `openclaw.agent.turn` span without a parent `openclaw.request`. This is expected.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ How OpenClaw observability works — both the official plugin and custom hook-ba
 │                                                                     │
 │  ┌─────────────────────────────────────────────────────────────┐   │
 │  │                      Agent Execution                         │   │
-│  │  message_received → before_agent_start → tool_calls →       │   │
+│  │  message_received → before_model_resolve →                  │   │
+│  │                     before_prompt_build → tool_calls →       │   │
 │  │                     tool_result_persist → agent_end          │   │
 │  └──────────────────────────┬──────────────────────────────────┘   │
 │                              │                                      │
@@ -145,7 +146,7 @@ OpenClaw drives plugins through three phases. Mixing them up is the single most 
 
 | Phase | Runs | Responsibility |
 |---|---|---|
-| `register()` | Synchronous, before the gateway accepts traffic | Wire every typed hook, event-stream hook, RPC method, CLI command, background service, and agent tool. All 15 typed hooks (`message_received`, `before_agent_start`, `tool_result_persist`, `agent_end`, plus the command and gateway event hooks) land here. |
+| `register()` | Synchronous, before the gateway accepts traffic | Wire every typed hook, event-stream hook, RPC method, CLI command, background service, and agent tool. Typed hooks (`message_received`, `before_model_resolve`, `before_prompt_build`, `llm_input`, `llm_output`, `tool_result_persist`, `message_sent`, `agent_end`, plus the command and gateway event hooks) land here. |
 | `start()` | Async, once the gateway is ready | Build the OTel runtime (`initTelemetry` → TracerProvider + MeterProvider), optionally wrap LLM SDKs with OpenLLMetry when `traces` is on, and subscribe to OpenClaw diagnostic events for cost/token data. |
 | `stop()` | Async, on gateway reload or shutdown | Clear the stale-session sweeper `setInterval` (see [b668a4f](https://github.com/henrikrexed/openclaw-observability-plugin/commit/b668a4f), ISI-522), unsubscribe from diagnostics, and call `telemetry.shutdown()` so batched spans/metrics flush before the process exits. |
 
@@ -195,9 +196,14 @@ Gateway Agent Loop              Custom Plugin
      │ ─────────────────────────────>│  ──> create ROOT span
      │                               │      store in sessionContextMap
      │                               │
-     │  on("before_agent_start")     │
+     │  on("before_model_resolve")   │
      │ ─────────────────────────────>│  ──> create AGENT TURN span
      │                               │      (child of root)
+     │                               │
+     │  on("before_prompt_build")    │
+     │ ─────────────────────────────>│  ──> enrich AGENT TURN span
+     │                               │      with prompt.chars +
+     │                               │      session.message_count
      │                               │
      │  on("tool_result_persist")    │
      │ ─────────────────────────────>│  ──> create TOOL span

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -106,7 +106,8 @@ You should see these lines **during `register()`** (before the gateway accepts t
 
 ```
 [otel] Registered message_received hook (via api.on)
-[otel] Registered before_agent_start hook (via api.on)
+[otel] Registered before_model_resolve hook (via api.on)
+[otel] Registered before_prompt_build hook (via api.on)
 [otel] Registered tool_result_persist hook (via api.on)
 [otel] Registered agent_end hook (via api.on)
 [otel] Registered command event hooks (via api.registerHook)

--- a/docs/telemetry/traces.md
+++ b/docs/telemetry/traces.md
@@ -42,7 +42,12 @@ Created by the `message_received` hook. This is the root span for the entire req
 
 ## Agent Turn Span
 
-Created by `before_agent_start`, ended by `agent_end`. Child of the request span.
+Created by the `before_model_resolve` hook at the earliest point in the agent
+run, enriched by `before_prompt_build` once session history is loaded, and
+ended by `agent_end`. Child of the request span.
+
+Prior to v0.2.0 this span was created in the legacy `before_agent_start` hook.
+See [CHANGELOG](../../CHANGELOG.md) and ISI-730 for the migration details.
 
 | Field | Value |
 |-------|-------|
@@ -55,7 +60,8 @@ Created by `before_agent_start`, ended by `agent_end`. Child of the request span
 |-----------|------|-------------|
 | `openclaw.agent.id` | string | Agent identifier |
 | `openclaw.session.key` | string | Session identifier |
-| `openclaw.agent.model` | string | Model requested |
+| `openclaw.prompt.chars` | int | Length of the user prompt (set by `before_prompt_build`) |
+| `openclaw.session.message_count` | int | Session history size fed to the LLM (set by `before_prompt_build`) |
 | `openclaw.agent.duration_ms` | int | Turn duration in milliseconds |
 | `openclaw.agent.success` | boolean | Whether the turn completed successfully |
 | `openclaw.agent.error` | string | Error message (if failed) |
@@ -63,6 +69,13 @@ Created by `before_agent_start`, ended by `agent_end`. Child of the request span
 | `gen_ai.usage.output_tokens` | int | Total output tokens |
 | `gen_ai.usage.total_tokens` | int | Sum of input + output tokens |
 | `gen_ai.response.model` | string | Actual model used (from last assistant message) |
+
+!!! note "`gen_ai.request.model` on the turn span"
+    The agent turn span no longer carries `gen_ai.request.model` — in
+    OpenClaw 2026.2+ the model has not been resolved when the span is
+    created (`before_model_resolve` fires pre-resolution). The resolved
+    model is recorded as `gen_ai.response.model` at `agent_end` and is
+    also available on `openclaw.llm.call` spans from the `llm_input` hook.
 
 !!! note "Token Counts"
     Token counts are **summed across all assistant messages** in the turn. If the agent makes multiple LLM calls (e.g., tool use loop), the totals reflect all calls combined. Cache tokens (`cacheRead`, `cacheWrite`) are included in the input token count.
@@ -121,9 +134,10 @@ Created when session commands are issued.
 The plugin maintains a `sessionContextMap` keyed by `sessionKey`:
 
 1. `message_received` creates a root span and stores its context
-2. `before_agent_start` creates an agent turn span as a child of the root
-3. `tool_result_persist` creates tool spans as children of the agent turn
-4. `agent_end` ends the agent turn and root spans, cleans up the context
+2. `before_model_resolve` creates an agent turn span as a child of the root
+3. `before_prompt_build` enriches the agent turn span with prompt/history attrs
+4. `tool_result_persist` creates tool spans as children of the agent turn
+5. `agent_end` ends the agent turn and root spans, cleans up the context
 
 Stale contexts (no `agent_end` within 5 minutes) are automatically cleaned up.
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,8 @@
   "id": "otel-observability",
   "name": "OpenTelemetry Observability",
   "description": "Traces, metrics, and logs for OpenClaw using OpenLLMetry and OpenTelemetry",
-  "version": "0.1.0",
+  "version": "0.2.0",
+  "minOpenClawVersion": "2026.2.0",
   "uiHints": {
     "endpoint": {
       "label": "OTLP Endpoint",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openclaw/otel-observability",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openclaw/otel-observability",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -22,7 +22,8 @@
         "@traceloop/node-server-sdk": "^0.22.6"
       },
       "devDependencies": {
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@cfworker/json-schema": {
@@ -30,6 +31,397 @@
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@google-cloud/opentelemetry-cloud-trace-exporter": {
       "version": "3.0.0",
@@ -99,6 +491,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -1098,6 +1497,356 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -1398,6 +2147,13 @@
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -1448,6 +2204,119 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
@@ -1524,6 +2393,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1565,6 +2444,16 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1588,6 +2477,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1631,6 +2537,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -1736,6 +2652,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1813,6 +2739,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1840,6 +2773,45 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1847,6 +2819,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -1883,6 +2865,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -1933,6 +2925,21 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2383,6 +3390,23 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2436,6 +3460,25 @@
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/node-fetch": {
@@ -2563,6 +3606,59 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
@@ -2679,6 +3775,51 @@
         "node": ">=14"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2711,10 +3852,41 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-wcswidth": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stream-events": {
@@ -2851,6 +4023,50 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2902,6 +4118,155 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -2916,6 +4281,23 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "@openclaw/otel-observability",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "OpenTelemetry observability plugin for OpenClaw — traces, metrics, and logs for your AI agent using OpenLLMetry",
   "type": "module",
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/ index.ts",
-    "test": "node --test instrumentation/*.test.mjs"
+    "test": "node --test instrumentation/*.test.mjs && vitest run"
   },
   "keywords": [
     "openclaw",
@@ -24,19 +26,20 @@
   "author": "Henrik Rexed",
   "license": "Apache-2.0",
   "dependencies": {
-    "@traceloop/node-server-sdk": "^0.22.6",
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.203.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
+    "@opentelemetry/resources": "^2.0.1",
+    "@opentelemetry/sdk-metrics": "^2.0.1",
     "@opentelemetry/sdk-node": "^0.203.0",
     "@opentelemetry/sdk-trace-node": "^2.0.1",
-    "@opentelemetry/sdk-metrics": "^2.0.1",
-    "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.203.0",
-    "@opentelemetry/resources": "^2.0.1",
-    "@opentelemetry/semantic-conventions": "^1.30.0"
+    "@opentelemetry/semantic-conventions": "^1.30.0",
+    "@traceloop/node-server-sdk": "^0.22.6"
   },
   "devDependencies": {
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -12,10 +12,20 @@
  *   └── (future: message.sent span)
  *
  * Context propagation:
- *   - message_received: creates root span, stores in sessionContextMap
- *   - before_agent_start: creates child "agent turn" span under root
- *   - tool_result_persist: creates child tool span under agent turn
- *   - agent_end: ends the agent turn span
+ *   - message_received:     creates root span, stores in sessionContextMap
+ *   - before_model_resolve: creates child "agent turn" span under root
+ *                           (fires earliest in the agent run, model not yet
+ *                           resolved — model attrs are populated later)
+ *   - before_prompt_build:  enriches the agent turn span with prompt length
+ *                           and session history size once messages are loaded
+ *   - tool_result_persist:  creates child tool span under agent turn
+ *   - agent_end:            ends the agent turn + root spans
+ *
+ * Hook migration note (ISI-730):
+ *   OpenClaw 2026.2+ treats `before_agent_start` as a legacy compatibility
+ *   hook and recommends `before_model_resolve` / `before_prompt_build` for
+ *   new work. This plugin is fully migrated — it no longer registers
+ *   `before_agent_start`. Minimum OpenClaw runtime is therefore 2026.2.x.
  *
  * IMPORTANT: OpenClaw has TWO hook registration systems:
  *   - api.registerHook() → event-stream hooks (command:new, gateway:startup)
@@ -163,16 +173,23 @@ export function registerHooks(
 
   logger.info("[otel] Registered message_received hook (via api.on)");
 
-  // ── before_agent_start ───────────────────────────────────────────
+  // ── before_model_resolve ─────────────────────────────────────────
   // Creates an "agent turn" child span under the root request span.
+  //
+  // Fires EARLIEST in the agent run, before provider/model resolution
+  // (OpenClaw 2026.2+). The resolved model is NOT known at this point —
+  // it is populated later from diagnostic events or at agent_end
+  // (as gen_ai.response.model).
+  //
+  // Replaces the legacy `before_agent_start` registration used by
+  // earlier plugin versions. See ISI-730.
 
   api.on(
-    "before_agent_start",
-    (event: any, ctx: any) => {
+    "before_model_resolve",
+    (_event: any, ctx: any) => {
       try {
-        const sessionKey = event?.sessionKey || ctx?.sessionKey || "unknown";
-        const agentId = event?.agentId || ctx?.agentId || "unknown";
-        const model = event?.model || "unknown";
+        const sessionKey = ctx?.sessionKey || "unknown";
+        const agentId = ctx?.agentId || "unknown";
 
         const sessionCtx = sessionContextMap.get(sessionKey);
         const parentContext = sessionCtx?.rootContext || context.active();
@@ -190,14 +207,15 @@ export function registerHooks(
               [GEN_AI_AGENT_ID]: agentId,
               [GEN_AI_AGENT_NAME]: agentId,
               [GEN_AI_CONVERSATION_ID]: sessionKey,
-              [GEN_AI_REQUEST_MODEL]: model,
+              // NOTE: gen_ai.request.model is intentionally omitted here.
+              // The model is still being resolved. gen_ai.response.model
+              // is written at agent_end from diagnostic usage events.
               // code.*
-              [CODE_FUNCTION]: "before_agent_start",
+              [CODE_FUNCTION]: "before_model_resolve",
               [CODE_NAMESPACE]: CODE_NS,
               // openclaw legacy (preserve for dashboards)
               "openclaw.agent.id": agentId,
               "openclaw.session.key": sessionKey,
-              "openclaw.agent.model": model,
             },
           },
           parentContext
@@ -228,13 +246,50 @@ export function registerHooks(
         // Silently ignore
       }
 
-      // Return undefined — don't modify system prompt
+      // Return undefined — we do not override provider/model.
       return undefined;
     },
     { priority: 90 }
   );
 
-  logger.info("[otel] Registered before_agent_start hook (via api.on)");
+  logger.info("[otel] Registered before_model_resolve hook (via api.on)");
+
+  // ── before_prompt_build ──────────────────────────────────────────
+  // Enriches the agent turn span with prompt + session-history context
+  // once the session messages are loaded (fires after before_model_resolve
+  // but before the LLM call). Produces two attributes:
+  //   - openclaw.prompt.chars         — raw user-prompt length for this turn
+  //   - openclaw.session.message_count — history size being fed to the LLM
+  //
+  // No return value — we never rewrite systemPrompt or prependContext.
+
+  api.on(
+    "before_prompt_build",
+    (event: any, ctx: any) => {
+      try {
+        const sessionKey = ctx?.sessionKey || "unknown";
+        const sessionCtx = sessionContextMap.get(sessionKey);
+        const agentSpan = sessionCtx?.agentSpan;
+        if (!agentSpan) {
+          return undefined;
+        }
+
+        const prompt = typeof event?.prompt === "string" ? event.prompt : "";
+        const messagesArr = Array.isArray(event?.messages) ? event.messages : [];
+
+        agentSpan.setAttribute("openclaw.prompt.chars", prompt.length);
+        agentSpan.setAttribute("openclaw.session.message_count", messagesArr.length);
+      } catch {
+        // Never let telemetry errors break the main flow
+      }
+
+      // Return undefined — we do not modify system prompt / prepend context.
+      return undefined;
+    },
+    { priority: 80 }
+  );
+
+  logger.info("[otel] Registered before_prompt_build hook (via api.on)");
 
   // ── llm_input ────────────────────────────────────────────────────
   // Start a CLIENT span for the outbound LLM call. The span is the

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Regression tests for plugin hook registration.
+ *
+ * Covers ISI-730: the plugin must no longer register `before_agent_start`
+ * and must register `before_model_resolve` + `before_prompt_build` instead.
+ * Span creation + attribute enrichment are exercised end-to-end against a
+ * stub `api` object that captures the typed handlers.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Counter, Histogram, Span, Tracer, UpDownCounter } from "@opentelemetry/api";
+
+import { registerHooks } from "../src/hooks.js";
+import type { OtelObservabilityConfig } from "../src/config.js";
+import type { TelemetryRuntime } from "../src/telemetry.js";
+
+// ── Test doubles ────────────────────────────────────────────────────
+
+interface SpanSpy {
+  attrs: Record<string, unknown>;
+  ended: boolean;
+  status: { code?: number; message?: string };
+  spanName: string;
+}
+
+function createSpanSpy(name: string): Span & SpanSpy {
+  const spy: SpanSpy = {
+    attrs: {},
+    ended: false,
+    status: {},
+    spanName: name,
+  };
+  const span = {
+    ...spy,
+    setAttribute(key: string, value: unknown) {
+      spy.attrs[key] = value;
+      return this;
+    },
+    setAttributes(values: Record<string, unknown>) {
+      Object.assign(spy.attrs, values);
+      return this;
+    },
+    setStatus(status: { code?: number; message?: string }) {
+      spy.status = status;
+      return this;
+    },
+    addEvent() {
+      return this;
+    },
+    addLink() {
+      return this;
+    },
+    addLinks() {
+      return this;
+    },
+    setStatusFromException() {
+      return this;
+    },
+    recordException() {
+      return this;
+    },
+    updateName(n: string) {
+      spy.spanName = n;
+      return this;
+    },
+    end() {
+      spy.ended = true;
+    },
+    isRecording() {
+      return !spy.ended;
+    },
+    spanContext() {
+      return { traceId: "t", spanId: "s", traceFlags: 1 };
+    },
+  };
+  return span as unknown as Span & SpanSpy;
+}
+
+function createTracerSpy(): { tracer: Tracer; spans: Array<Span & SpanSpy> } {
+  const spans: Array<Span & SpanSpy> = [];
+  const tracer = {
+    startSpan(name: string, options?: { attributes?: Record<string, unknown> }) {
+      const span = createSpanSpy(name);
+      if (options?.attributes) {
+        Object.assign((span as unknown as SpanSpy).attrs, options.attributes);
+      }
+      spans.push(span);
+      return span;
+    },
+    startActiveSpan: (() => {
+      throw new Error("startActiveSpan not used by hooks");
+    }) as Tracer["startActiveSpan"],
+  } as Tracer;
+  return { tracer, spans };
+}
+
+function noopCounter(): Counter {
+  return { add: vi.fn() } as unknown as Counter;
+}
+function noopUpDownCounter(): UpDownCounter {
+  return { add: vi.fn() } as unknown as UpDownCounter;
+}
+function noopHistogram(): Histogram {
+  return { record: vi.fn() } as unknown as Histogram;
+}
+
+function createTelemetry(): { telemetry: TelemetryRuntime; spans: Array<Span & SpanSpy> } {
+  const { tracer, spans } = createTracerSpy();
+  const telemetry: TelemetryRuntime = {
+    tracer,
+    meter: {} as TelemetryRuntime["meter"],
+    counters: {
+      llmRequests: noopCounter(),
+      llmErrors: noopCounter(),
+      tokensTotal: noopCounter(),
+      tokensPrompt: noopCounter(),
+      tokensCompletion: noopCounter(),
+      toolCalls: noopCounter(),
+      toolErrors: noopCounter(),
+      sessionResets: noopCounter(),
+      messagesReceived: noopCounter(),
+      messagesSent: noopCounter(),
+      securityEvents: noopCounter(),
+      sensitiveFileAccess: noopCounter(),
+      promptInjection: noopCounter(),
+      dangerousCommand: noopCounter(),
+    } as unknown as TelemetryRuntime["counters"],
+    histograms: {
+      agentTurnDuration: noopHistogram(),
+      genAiTokenUsage: noopHistogram(),
+      genAiOperationDuration: noopHistogram(),
+    } as unknown as TelemetryRuntime["histograms"],
+    gauges: {} as unknown as TelemetryRuntime["gauges"],
+    shutdown: async () => {},
+  };
+  return { telemetry, spans };
+}
+
+type TypedHandler = (event: unknown, ctx: unknown) => unknown;
+type EventStreamHandler = (event: unknown) => unknown;
+
+function createStubApi() {
+  const typedHooks = new Map<string, TypedHandler>();
+  const eventStreamHooks = new Map<string, EventStreamHandler>();
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const api = {
+    logger,
+    on(name: string, handler: TypedHandler) {
+      typedHooks.set(name, handler);
+    },
+    registerHook(events: string | string[], handler: EventStreamHandler) {
+      const list = Array.isArray(events) ? events : [events];
+      for (const ev of list) {
+        eventStreamHooks.set(ev, handler);
+      }
+    },
+  };
+  return { api, typedHooks, eventStreamHooks, logger };
+}
+
+const config: OtelObservabilityConfig = {
+  endpoint: "http://localhost:4318",
+  protocol: "http",
+  serviceName: "test",
+  headers: {},
+  traces: true,
+  metrics: true,
+  logs: false,
+  captureContent: false,
+  metricsIntervalMs: 30_000,
+  resourceAttributes: {},
+};
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("plugin hook registration (ISI-730 migration)", () => {
+  let stopHooks: () => void;
+
+  beforeEach(() => {
+    // nothing — each test sets up its own stubs
+  });
+
+  it("registers the new phase hooks and NOT the legacy before_agent_start", () => {
+    const { api, typedHooks, logger } = createStubApi();
+    const { telemetry } = createTelemetry();
+
+    stopHooks = registerHooks(api, telemetry, config);
+
+    expect(typedHooks.has("before_model_resolve")).toBe(true);
+    expect(typedHooks.has("before_prompt_build")).toBe(true);
+    expect(typedHooks.has("before_agent_start")).toBe(false);
+
+    // Other existing typed hooks are still registered.
+    expect(typedHooks.has("message_received")).toBe(true);
+    expect(typedHooks.has("llm_input")).toBe(true);
+    expect(typedHooks.has("llm_output")).toBe(true);
+    expect(typedHooks.has("tool_result_persist")).toBe(true);
+    expect(typedHooks.has("message_sent")).toBe(true);
+    expect(typedHooks.has("agent_end")).toBe(true);
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "[otel] Registered before_model_resolve hook (via api.on)",
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      "[otel] Registered before_prompt_build hook (via api.on)",
+    );
+
+    stopHooks();
+  });
+
+  it("before_model_resolve creates an agent.turn span with agent_id + session_key", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, telemetry, config);
+
+    const handler = typedHooks.get("before_model_resolve");
+    expect(handler).toBeDefined();
+    const result = handler!({ prompt: "hi" }, {
+      agentId: "claude-4",
+      sessionKey: "session-123",
+    });
+    // Must NOT return a value — we do not override provider/model.
+    expect(result).toBeUndefined();
+
+    const turnSpan = spans.find((s) => s.spanName === "openclaw.agent.turn");
+    expect(turnSpan).toBeDefined();
+    expect(turnSpan!.attrs["openclaw.agent.id"]).toBe("claude-4");
+    expect(turnSpan!.attrs["openclaw.session.key"]).toBe("session-123");
+    expect(turnSpan!.attrs["gen_ai.agent.id"]).toBe("claude-4");
+    expect(turnSpan!.attrs["gen_ai.conversation.id"]).toBe("session-123");
+    expect(turnSpan!.attrs["code.function"]).toBe("before_model_resolve");
+    // Model is NOT known at this point — must NOT be set.
+    expect(turnSpan!.attrs["gen_ai.request.model"]).toBeUndefined();
+    expect(turnSpan!.attrs["openclaw.agent.model"]).toBeUndefined();
+
+    stopHooks();
+  });
+
+  it("before_prompt_build enriches the existing agent.turn span with prompt + history size", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, telemetry, config);
+
+    const resolveHandler = typedHooks.get("before_model_resolve")!;
+    const buildHandler = typedHooks.get("before_prompt_build")!;
+
+    // 1. agent turn span starts in before_model_resolve
+    resolveHandler({ prompt: "hi" }, { agentId: "a", sessionKey: "s" });
+
+    // 2. before_prompt_build enriches it
+    const out = buildHandler(
+      {
+        prompt: "user asked about X",
+        messages: [{ role: "user" }, { role: "assistant" }, { role: "user" }],
+      },
+      { agentId: "a", sessionKey: "s" },
+    );
+    expect(out).toBeUndefined();
+
+    const turnSpan = spans.find((s) => s.spanName === "openclaw.agent.turn");
+    expect(turnSpan).toBeDefined();
+    expect(turnSpan!.attrs["openclaw.prompt.chars"]).toBe("user asked about X".length);
+    expect(turnSpan!.attrs["openclaw.session.message_count"]).toBe(3);
+
+    stopHooks();
+  });
+
+  it("before_prompt_build is a no-op when no agent span has been started", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, telemetry, config);
+
+    const buildHandler = typedHooks.get("before_prompt_build")!;
+    // Never ran before_model_resolve → no agent span exists.
+    const out = buildHandler(
+      { prompt: "x", messages: [] },
+      { agentId: "a", sessionKey: "orphan-session" },
+    );
+    expect(out).toBeUndefined();
+    // No agent.turn span created by the build hook.
+    expect(spans.find((s) => s.spanName === "openclaw.agent.turn")).toBeUndefined();
+
+    stopHooks();
+  });
+
+  it("end-to-end: message_received → before_model_resolve → before_prompt_build produces a connected turn span", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, telemetry, config);
+
+    const received = typedHooks.get("message_received")!;
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const build = typedHooks.get("before_prompt_build")!;
+
+    // Await message_received — async handler.
+    return Promise.resolve(
+      received(
+        { channel: "cli", sessionKey: "s1", from: "user" },
+        { sessionKey: "s1" },
+      ),
+    ).then(() => {
+      resolve({ prompt: "hi" }, { agentId: "a1", sessionKey: "s1" });
+      build({ prompt: "hi", messages: [] }, { agentId: "a1", sessionKey: "s1" });
+
+      const request = spans.find((s) => s.spanName === "openclaw.request");
+      const turn = spans.find((s) => s.spanName === "openclaw.agent.turn");
+      expect(request).toBeDefined();
+      expect(turn).toBeDefined();
+      expect(turn!.attrs["openclaw.session.key"]).toBe("s1");
+      expect(turn!.attrs["openclaw.agent.id"]).toBe("a1");
+
+      stopHooks();
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Migrates the `otel-observability` OpenClaw plugin off the deprecated `before_agent_start` hook to the new `before_model_resolve` + `before_prompt_build` hook pair.

Parent tracking issue: ISI-729 (plugin compatibility). This ticket: ISI-730.

## Scope delivered

- **Hook split.** `before_agent_start` registration removed from `src/hooks.ts`. Replaced by:
  - `before_model_resolve` — creates the `openclaw.agent.turn` span at the earliest point in the agent run.
  - `before_prompt_build` — enriches the span with `openclaw.prompt.chars` + `openclaw.session.message_count`.
- **No compat shim.** Both replacement hooks ship with OpenClaw 2026.2, so the plugin sets `minOpenClawVersion: 2026.2.0` and bumps to `0.2.0`. Anyone still on `< 2026.2` pins to `0.1.x`.
- **Regression tests.** Added `tests/hooks.test.ts` + vitest dev-dep. 5 cases: hook wiring, no legacy `before_agent_start` registered, span creation on resolve, span enrichment on build, build-without-resolve no-op, end-to-end.
- **Docs.** `README.md`, `docs/architecture.md`, `docs/getting-started.md`, `docs/telemetry/traces.md`, new `CHANGELOG.md` — all updated.

## Before / after telemetry on `openclaw.agent.turn`

| Attribute | v0.1.x (`before_agent_start`) | v0.2.0 (`before_model_resolve` + `before_prompt_build`) |
|---|---|---|
| `gen_ai.operation.name` | `invoke_agent` | `invoke_agent` |
| `gen_ai.agent.id` / `gen_ai.agent.name` | agentId | agentId |
| `gen_ai.conversation.id` | sessionKey | sessionKey |
| `gen_ai.request.model` | `"unknown"` (hook event never had it) | **omitted** — `gen_ai.response.model` still set at `agent_end` |
| `openclaw.agent.id` / `openclaw.session.key` | set | set |
| `openclaw.agent.model` | `"unknown"` | **omitted** (was always `"unknown"` anyway) |
| `code.function` | `before_agent_start` | `before_model_resolve` |
| `openclaw.prompt.chars` | — | **new** (set by `before_prompt_build`) |
| `openclaw.session.message_count` | — | **new** (set by `before_prompt_build`) |

Net effect: two always-`"unknown"` attributes dropped from the turn span; two new context attributes added; everything else preserved end-to-end through to `agent_end`. Tool spans, LLM spans, cost/token data untouched.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 5/5 pass on `tests/hooks.test.ts`.
- [x] Verified `src/hooks.ts` no longer registers `before_agent_start`; only `before_model_resolve` + `before_prompt_build` wired.
- [x] Design call on dropping `gen_ai.request.model` / `openclaw.agent.model` approved by BigBoss on ISI-730 — both were always `"unknown"` on `before_agent_start`, `gen_ai.response.model` still emitted at `agent_end`.

🤖 Co-Authored-By: Paperclip <noreply@paperclip.ing>