### PR TITLE
feat: wire captureContent to Traceloop traceContent (ISI-733/ISI-734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the OpenClaw OTel Observability Plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Changed
+
+- **`captureContent` is now wired end-to-end to Traceloop LLM-client spans.** Setting `captureContent: true` in the plugin config (plus `OPENCLAW_OTEL_CAPTURE_CONTENT=true` in the gateway's environment, read by `instrumentation/preload.mjs` before Traceloop loads) causes `@traceloop/instrumentation-anthropic` and `@traceloop/instrumentation-openai` to record prompt and completion text as `gen_ai.prompt.*` / `gen_ai.completion.*` span attributes. Previously the option was accepted but had no effect on LLM-client spans.
+  - Default stays `false` (privacy-first).
+  - `captureContent` is a **gateway-launch setting, not hot-reloadable** — the preload runs before plugin config is parsed, so the Traceloop instrumentations are constructed once at process start. Restart the gateway to pick up changes.
+  - The plugin logs a warning at `start()` if the config and the preload's resolved env-var value disagree.
+  - See [docs/security/privacy.md](docs/security/privacy.md) and [docs/configuration.md](docs/configuration.md#capturecontent-gateway-launch-setting).
+  - Resolves [github issue #15](https://github.com/henrikrexed/openclaw-observability-plugin/issues/15) (ISI-733 / ISI-734).
+
+### Added
+
+- `instrumentation/capture-content.mjs` exports `resolveCaptureContent(env)` and the `CAPTURE_CONTENT_ENV` constant, consumed by the preload and covered by `instrumentation/capture-content.test.mjs` (`npm test`, uses `node --test`).
+- `docs/security/privacy.md` — new page covering the privacy implications of `captureContent`, how to enable it safely, and redaction guidance.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,8 +232,72 @@ OpenClaw also respects standard OTel environment variables as fallbacks:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Default OTLP endpoint |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | Default protocol |
 | `OTEL_SERVICE_NAME` | Default service name |
+| `OPENCLAW_OTEL_CAPTURE_CONTENT` | `true` to capture LLM prompt/completion text in Traceloop spans. See [captureContent (gateway-launch setting)](#capturecontent-gateway-launch-setting). |
 
 Config file values take precedence over environment variables.
+
+## `captureContent` (gateway-launch setting)
+
+The custom plugin exposes a `captureContent` boolean in `plugins.entries.otel-observability.config`. When `true`, Traceloop-instrumented LLM-client spans (`@traceloop/instrumentation-anthropic`, `@traceloop/instrumentation-openai`) include the actual prompt/completion text as `gen_ai.prompt.*` and `gen_ai.completion.*` attributes.
+
+**Default: `false` (privacy-first).** The schema help text already advertises this toggle; see [github issue #15](https://github.com/henrikrexed/openclaw-observability-plugin/issues/15) for the motivating report.
+
+### Not hot-reloadable
+
+`captureContent` is a **gateway-launch setting**, not a hot-reloadable plugin option, because the ESM preload (`instrumentation/preload.mjs`) instantiates `AnthropicInstrumentation` and `OpenAIInstrumentation` *before* OpenClaw parses plugin config. Changing the value in `openclaw.json` mid-run has no effect until the next gateway restart.
+
+### How to enable content capture
+
+Set both the plugin config **and** the environment variable before launching the gateway:
+
+```bash
+OPENCLAW_OTEL_CAPTURE_CONTENT=true \
+  NODE_OPTIONS="--import /path/to/openclaw-observability-plugin/instrumentation/preload.mjs" \
+  openclaw gateway start
+```
+
+Or via systemd:
+
+```ini
+[Service]
+Environment=OPENCLAW_OTEL_CAPTURE_CONTENT=true
+Environment=NODE_OPTIONS=--import /path/to/openclaw-observability-plugin/instrumentation/preload.mjs
+ExecStart=/usr/bin/openclaw gateway start
+```
+
+Plugin config:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "captureContent": true
+        }
+      }
+    }
+  }
+}
+```
+
+### Mismatch warning
+
+If the plugin config says `captureContent: true` but the env var was unset (or `false`) when the gateway launched, the preload will have wired the Traceloop instrumentations with `traceContent: false`. At plugin `start()` the plugin logs a warning like:
+
+```
+[otel] captureContent=true in plugin config but the preload resolved
+OPENCLAW_OTEL_CAPTURE_CONTENT=false at gateway launch. Traceloop LLM-client
+spans will use the preload's value. Set OPENCLAW_OTEL_CAPTURE_CONTENT=true
+in the gateway's environment before starting (see docs/security/privacy.md).
+```
+
+Fix by setting the env var and restarting the gateway.
+
+### Privacy guidance
+
+Leave `captureContent` at `false` unless you control the backend and understand the implications. See [Privacy: `captureContent`](./security/privacy.md) for a fuller treatment.
 
 ## Applying Changes
 

--- a/docs/security/privacy.md
+++ b/docs/security/privacy.md
@@ -1,0 +1,118 @@
+# Privacy: `captureContent`
+
+The `captureContent` plugin option controls whether the Traceloop LLM-client instrumentations (`@traceloop/instrumentation-anthropic`, `@traceloop/instrumentation-openai`) record the **actual prompt and completion text** of every LLM call as span attributes.
+
+Default: `false` (privacy-first).
+
+## What `captureContent` controls
+
+With `captureContent: true`, Traceloop LLM-client spans include:
+
+| Span attribute | Contents |
+|----------------|----------|
+| `gen_ai.prompt.N.role` | Role for message *N* (e.g., `user`, `assistant`, `system`). |
+| `gen_ai.prompt.N.content` | **Full message text** for message *N*. |
+| `gen_ai.completion.N.role` | Role of the model's response. |
+| `gen_ai.completion.N.content` | **Full generated text** from the model. |
+
+With `captureContent: false`, those attributes are **omitted**. Token counts, model identifiers, latency, cost, and error state are still recorded — the behavioral metrics are unchanged.
+
+## What `captureContent` does **not** affect
+
+`captureContent` only gates the Traceloop LLM-client spans described above. It does **not** touch the plugin's own hook-surface spans, which already emit only metadata:
+
+- `openclaw.request` — session/channel identifiers, no message body
+- `openclaw.agent.turn` — token counts, model, duration; no prompt/completion text
+- `tool.*` — tool name, duration, truncated input/result **preview** only (see `src/security.ts` for redaction rules)
+- `message_sent` — metadata only
+
+If you need to exclude tool-call previews too, that is controlled separately in the hook layer, not by `captureContent`.
+
+## Gateway-launch setting (not hot-reloadable)
+
+`captureContent` is read by the ESM preload (`instrumentation/preload.mjs`) at gateway launch time, **before** OpenClaw parses plugin config. The Traceloop instrumentations are constructed once, at preload, and the `traceContent` option is fixed for the lifetime of the process.
+
+Consequence: changing `captureContent` in `openclaw.json` mid-run has no effect until the next gateway restart.
+
+### Bridge mechanism
+
+The preload reads the `OPENCLAW_OTEL_CAPTURE_CONTENT` environment variable. The plugin's `start()` phase re-exports this env var from the parsed plugin config so subprocesses inherit the intended value, and warns if the preload resolved to a different value than the plugin config requests.
+
+### How to enable
+
+Set the env var **before** the gateway process starts:
+
+```bash
+OPENCLAW_OTEL_CAPTURE_CONTENT=true \
+  NODE_OPTIONS="--import /path/to/openclaw-observability-plugin/instrumentation/preload.mjs" \
+  openclaw gateway start
+```
+
+Or via systemd:
+
+```ini
+[Service]
+Environment=OPENCLAW_OTEL_CAPTURE_CONTENT=true
+Environment=NODE_OPTIONS=--import /path/to/openclaw-observability-plugin/instrumentation/preload.mjs
+ExecStart=/usr/bin/openclaw gateway start
+```
+
+Plugin config for parity (so the `otel_status` tool and the mismatch warning agree):
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "captureContent": true
+        }
+      }
+    }
+  }
+}
+```
+
+The env-var value must be the exact string `true`. Anything else — `1`, `yes`, `True`, unset — resolves to `false`. The strict match exists to keep the privacy default unambiguous.
+
+## When to enable content capture
+
+Enabling `captureContent` is a deliberate tradeoff. Useful when:
+
+- You are debugging prompt engineering and need to see actual prompt/completion pairs alongside token counts.
+- You operate the OTLP backend and downstream storage yourself.
+- You have reviewed the backend's retention and access controls against the sensitivity of the prompts your agents handle.
+
+Avoid enabling content capture when:
+
+- Users can pass arbitrary data into the agent (free-form chat, uploaded documents, customer PII).
+- Your backend retention is long, retention controls are weak, or access is broad.
+- You have regulatory obligations around prompt/completion text (HIPAA, PCI, GDPR right-to-erasure).
+
+## Sensitive data reaching spans
+
+When `captureContent: true`, any of the following can land in span storage:
+
+- User chat input, including PII, credentials, or proprietary data.
+- Document contents summarized into prompts.
+- Tool outputs fed back to the model (e.g., file contents from `tool.Read`).
+- System prompts, which may encode prompt-engineering IP you don't want to expose.
+
+The plugin does **not** scrub Traceloop span attributes before export. If you need redaction, apply it at the OTel Collector (`transform` / `attributes` processors) or at the backend.
+
+## Complementary detections
+
+Whether or not you capture content, the real-time [detection module](./detection.md) runs on the hook-surface path and flags:
+
+- Sensitive file access (`tool.Read` on `.env`, SSH keys, cloud creds)
+- Dangerous command execution
+- Prompt-injection patterns on inbound messages
+
+These alerts work without content capture — they operate on paths, command strings, and matched patterns, and emit only the patterns and a short preview on the span.
+
+## See also
+
+- [Real-Time Detection](./detection.md) — application-layer security events
+- [Configuration](../configuration.md#capturecontent-gateway-launch-setting) — plugin config reference
+- [github issue #15](https://github.com/henrikrexed/openclaw-observability-plugin/issues/15) — original report motivating this wiring

--- a/index.ts
+++ b/index.ts
@@ -132,6 +132,23 @@ const otelObservabilityPlugin = {
         // they work in both gateway and embedded runner contexts. Only
         // gateway-specific work lives here.
 
+        // Bridge captureContent → OPENCLAW_OTEL_CAPTURE_CONTENT env var.
+        // The preload reads this env at gateway launch, but any subprocess
+        // spawned later inherits it from here too. If the preload was
+        // already active with a mismatched value, LLM-client spans will
+        // reflect the preload's value (not the plugin config) — warn so
+        // operators know to set the env var before launching the gateway.
+        const preloadActive = (globalThis as any).__OPENCLAW_OTEL_PRELOAD_ACTIVE === true;
+        const preloadResolved = (globalThis as any).__OPENCLAW_OTEL_CAPTURE_CONTENT;
+        if (preloadActive && preloadResolved !== config.captureContent) {
+          logger.warn(
+            `[otel] captureContent=${config.captureContent} in plugin config but the preload resolved OPENCLAW_OTEL_CAPTURE_CONTENT=${preloadResolved} at gateway launch. ` +
+              `Traceloop LLM-client spans will use the preload's value. ` +
+              `Set OPENCLAW_OTEL_CAPTURE_CONTENT=${config.captureContent} in the gateway's environment before starting (see docs/security/privacy.md).`
+          );
+        }
+        process.env.OPENCLAW_OTEL_CAPTURE_CONTENT = String(config.captureContent);
+
         // 1. Wrap LLM SDKs. The wraps use trace.getTracer() which goes
         //    through the provider we registered above. OpenLLMetry's
         //    IITM preload only matters in the long-running gateway

--- a/instrumentation/capture-content.mjs
+++ b/instrumentation/capture-content.mjs
@@ -1,0 +1,17 @@
+/**
+ * Resolve the Traceloop `traceContent` flag from the environment.
+ *
+ * `captureContent` on the plugin config controls whether LLM prompt/completion
+ * text is recorded on Traceloop spans. Because the preload runs *before* the
+ * plugin's `start()` phase (NODE_OPTIONS=--import loads it before anything
+ * else), the value must be bridged through an environment variable that is
+ * set by whatever launches the gateway.
+ *
+ * Strict string match on 'true'. Any other value (including '1', 'True',
+ * 'yes', unset) resolves to `false` so privacy-first stays the default.
+ */
+export function resolveCaptureContent(env = process.env) {
+  return env.OPENCLAW_OTEL_CAPTURE_CONTENT === "true";
+}
+
+export const CAPTURE_CONTENT_ENV = "OPENCLAW_OTEL_CAPTURE_CONTENT";

--- a/instrumentation/capture-content.test.mjs
+++ b/instrumentation/capture-content.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * Sanity test for the captureContent → traceContent wiring.
+ *
+ * The preload uses `resolveCaptureContent(process.env)` to decide whether
+ * Traceloop records prompt/completion text on LLM-client spans. This test
+ * pins the resolution semantics so a future regression that (for example)
+ * loosens the comparison to truthy won't silently change the privacy
+ * default from `false` to `true`.
+ *
+ * Run with: npm test
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveCaptureContent, CAPTURE_CONTENT_ENV } from "./capture-content.mjs";
+
+test("returns false when env var is unset", () => {
+  assert.equal(resolveCaptureContent({}), false);
+});
+
+test("returns true only for the exact lowercase string 'true'", () => {
+  assert.equal(resolveCaptureContent({ [CAPTURE_CONTENT_ENV]: "true" }), true);
+});
+
+test("returns false for 'false'", () => {
+  assert.equal(resolveCaptureContent({ [CAPTURE_CONTENT_ENV]: "false" }), false);
+});
+
+test("returns false for other truthy strings (privacy-first default)", () => {
+  for (const value of ["1", "yes", "True", "TRUE", "on", " true ", "enabled"]) {
+    assert.equal(
+      resolveCaptureContent({ [CAPTURE_CONTENT_ENV]: value }),
+      false,
+      `expected '${value}' to resolve to false`
+    );
+  }
+});
+
+test("returns false for empty string", () => {
+  assert.equal(resolveCaptureContent({ [CAPTURE_CONTENT_ENV]: "" }), false);
+});
+
+test("exports the env var name so callers stay in sync", () => {
+  assert.equal(CAPTURE_CONTENT_ENV, "OPENCLAW_OTEL_CAPTURE_CONTENT");
+});

--- a/instrumentation/preload.mjs
+++ b/instrumentation/preload.mjs
@@ -11,6 +11,7 @@
 import { register } from 'node:module';
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
+import { resolveCaptureContent } from './capture-content.mjs';
 
 // Step 1: Register IITM as an ESM module loader hook
 // This MUST happen before any instrumented modules are imported.
@@ -28,6 +29,7 @@ const { OpenAIInstrumentation } = await import("@traceloop/instrumentation-opena
 
 const OTLP_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318";
 const SERVICE_NAME = process.env.OTEL_SERVICE_NAME || "openclaw-gateway";
+const TRACE_CONTENT = resolveCaptureContent();
 
 const resource = resourceFromAttributes({
   "service.name": SERVICE_NAME,
@@ -43,17 +45,19 @@ const sdk = new NodeSDK({
   resource,
   spanProcessors: [new BatchSpanProcessor(traceExporter)],
   instrumentations: [
-    new AnthropicInstrumentation({ traceContent: false }),
-    new OpenAIInstrumentation({ traceContent: false }),
+    new AnthropicInstrumentation({ traceContent: TRACE_CONTENT }),
+    new OpenAIInstrumentation({ traceContent: TRACE_CONTENT }),
   ],
 });
 
 sdk.start();
 
-// Signal to the plugin that preload is active
+// Signal to the plugin that preload is active, and publish the resolved
+// traceContent state so the plugin can detect config/env mismatches.
 globalThis.__OPENCLAW_OTEL_PRELOAD_ACTIVE = true;
+globalThis.__OPENCLAW_OTEL_CAPTURE_CONTENT = TRACE_CONTENT;
 
 process.on("SIGTERM", () => sdk.shutdown());
 process.on("SIGINT", () => sdk.shutdown());
 
-console.log(`[otel-preload] GenAI instrumentation active (endpoint=${OTLP_ENDPOINT}, IITM loader registered)`);
+console.log(`[otel-preload] GenAI instrumentation active (endpoint=${OTLP_ENDPOINT}, captureContent=${TRACE_CONTENT}, IITM loader registered)`);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Generic OTLP: backends/generic-otlp.md
   - Security:
     - Real-Time Detection: security/detection.md
+    - Privacy (captureContent): security/privacy.md
     - Kernel Monitoring with Tetragon: security/tetragon.md
   - Architecture: architecture.md
   - Limitations: limitations.md

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/ index.ts"
+    "lint": "eslint src/ index.ts",
+    "test": "node --test instrumentation/*.test.mjs"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
## Summary

Resolves [github issue #15](https://github.com/henrikrexed/openclaw-observability-plugin/issues/15) (ISI-733 / ISI-734). The plugin's `captureContent` option was advertised in the schema help text but wired to nothing — the preload hard-coded `traceContent: false` on both Traceloop LLM-client instrumentations. This PR implements the option end-to-end.

- Preload now reads `OPENCLAW_OTEL_CAPTURE_CONTENT` (strict `'true'` match) and passes the resolved boolean to `AnthropicInstrumentation` and `OpenAIInstrumentation`. Default stays `false` (privacy-first).
- Plugin `start()` re-exports the env var from parsed config for subprocesses and warns if the preload resolved to a different value than the config (the preload runs before plugin config is parsed, so the env var is the source of truth at gateway launch).
- Shared resolution lives in `instrumentation/capture-content.mjs`, covered by `instrumentation/capture-content.test.mjs` via `node --test` (`npm test`).
- Docs: new `docs/security/privacy.md`; `docs/configuration.md` gains a `captureContent (gateway-launch setting)` section explaining it is not hot-reloadable and how to enable via env var / systemd.
- `CHANGELOG.md` created with an Unreleased entry covering the behavior change.

Default stays `false`, and hook-surface spans (`openclaw.agent.turn`, `tool.*`, `message_sent`) are untouched.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 6/6 pass (`node --test instrumentation/*.test.mjs`)
- [ ] Manual boot with `OPENCLAW_OTEL_CAPTURE_CONTENT=true`: confirm Traceloop LLM-client spans carry `gen_ai.prompt.*` / `gen_ai.completion.*`
- [ ] Manual boot with env unset: confirm those attributes are absent
- [ ] Manual: set `captureContent: true` in plugin config but leave env unset — confirm the plugin logs the mismatch warning at `start()`