### PR TITLE
ISI-735: add SUPPORT.md, CONTRIBUTING.md backport rules, README support matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing
+
+Thanks for helping improve the OpenClaw OTel Observability Plugin. This document covers the parts of the workflow that are specific to this repo. General Git/GitHub etiquette applies otherwise.
+
+## Branching model
+
+This project uses a two-track support model. Before you start, please read [`SUPPORT.md`](SUPPORT.md).
+
+| Track   | Branch            | OpenClaw range      | Accepts                                                     |
+| ------- | ----------------- | ------------------- | ----------------------------------------------------------- |
+| `0.2.x` | `main`            | `>= 2026.4.21`      | Features, new attributes, new hooks, refactors, bug fixes.  |
+| `0.1.x` | `release/0.1.x`   | `< 2026.4.21`       | Security fixes and critical regressions **only**, cherry-picked from `main`. |
+
+All day-to-day work targets `main`.
+
+## PR labels
+
+Every PR MUST carry exactly one `track/*` label so triage and release notes are unambiguous:
+
+- **`track/0.2`** — PRs targeting `main` (the default).
+- **`track/0.1`** — PRs targeting `release/0.1.x` (cherry-picks only).
+
+If you forget the label, a maintainer will add it before merge.
+
+## Backports to `release/0.1.x`
+
+The `release/0.1.x` branch is in **maintenance** through **2026-10-21**. It accepts security fixes and critical regressions that apply to OpenClaw `< 2026.4.21`.
+
+The discipline is strict to keep the branch stable:
+
+1. **Fix on `main` first.** Open a normal PR against `main` and get it merged. Label it `track/0.2`.
+2. **Decide whether it backports.** A change qualifies for backport if **all** of the following hold:
+   - It is a security fix or a critical regression (not a feature, not a cleanup).
+   - It applies to OpenClaw `< 2026.4.21` (i.e., the bug reproduces on `0.1.x`).
+   - It does not depend on hooks or APIs that only exist in OpenClaw `>= 2026.4.21`.
+3. **Cherry-pick to `release/0.1.x`.** Do **not** merge `main` into `release/0.1.x`; cherry-pick the specific commit(s) instead. From a clean checkout:
+   ```bash
+   git fetch origin
+   git checkout -b backport/<short-desc>-0.1.x origin/release/0.1.x
+   git cherry-pick -x <merge-commit-sha-or-range>
+   # resolve conflicts if any, keep the change minimal
+   git push -u origin backport/<short-desc>-0.1.x
+   ```
+   The `-x` flag adds a `(cherry picked from commit …)` trailer so the backport is traceable back to `main`.
+4. **Open a PR targeting `release/0.1.x`.**
+   - Base branch: `release/0.1.x` (not `main`).
+   - Label the PR **`track/0.1`**.
+   - In the description, link the original `main` PR and note why it qualifies under the backport rules above.
+5. **Do not land new work on `release/0.1.x` directly.** Cherry-picks only. If something on `0.1.x` cannot be expressed as a cherry-pick from `main`, open a `track/0.2` discussion issue first so we can decide how to handle it (usually: fix it on `main` in a form that backports cleanly).
+
+### After EOL (2026-10-21)
+
+Once the `release/0.1.x` window closes:
+
+- No further cherry-picks are accepted.
+- The branch is archived (not deleted) so consumers can still fetch it.
+- Open bug reports on `track/0.1` will be closed with a pointer to upgrade OpenClaw to `>= 2026.4.21` and the plugin to `0.2.x`.
+
+The maintainers may accelerate or extend this date; watch [`SUPPORT.md`](SUPPORT.md) for the authoritative window.
+
+## Development
+
+- Run `npm test` before opening a PR.
+- Keep CHANGELOG entries under `[Unreleased]` until a release is cut; move them to a versioned section at release time.
+- If a change affects the plugin↔OpenClaw compatibility surface, update `openclaw.plugin.json` (`minOpenClawVersion`), [`CHANGELOG.md`](CHANGELOG.md), and [`SUPPORT.md`](SUPPORT.md) in the same PR.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@ OpenTelemetry observability for [OpenClaw](https://github.com/openclaw/openclaw)
 
 📖 **[Full Documentation](https://henrikrexed.github.io/openclaw-observability-plugin/)** — Setup guides, configuration reference, and backend examples.
 
+## Support matrix
+
+The plugin follows a two-track support model. Pick the plugin track that matches your OpenClaw Gateway version. See [`SUPPORT.md`](SUPPORT.md) for the full policy, and [`CONTRIBUTING.md`](CONTRIBUTING.md#backports-to-release01x) for the backport workflow.
+
+| Plugin track | OpenClaw range    | Branch           | Status                                                   | Window                                         |
+| ------------ | ----------------- | ---------------- | -------------------------------------------------------- | ---------------------------------------------- |
+| `0.1.x`      | `< 2026.4.21`     | `release/0.1.x`  | Maintenance — security + critical regressions only        | Through **2026-10-21**                         |
+| `0.2.x`      | `>= 2026.4.21`    | `main`           | Active — features, new attributes, new hooks              | Default going forward                          |
+
+> OpenClaw `2026.4.21` introduced the `before_model_resolve` and `before_prompt_build` hooks and deprecated `before_agent_start`. The `0.2.x` line targets the new hooks; the `0.1.x` line remains on the legacy hook for existing deployments.
+
 ## Two Approaches to Observability
 
 This repository documents **two complementary approaches** to monitoring OpenClaw:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,51 @@
+# Support Policy
+
+This project follows a **two-track support model** aligned to OpenClaw Gateway versions and to the plugin hook API surface that each OpenClaw line exposes.
+
+OpenClaw `2026.4.21` introduced the new `before_model_resolve` and `before_prompt_build` plugin hooks, and emits a deprecation warning for the older `before_agent_start` hook. The plugin tracks this split directly.
+
+## Policy
+
+| Track    | OpenClaw range         | Branch           | Status                                                   | Support window                                  |
+| -------- | ---------------------- | ---------------- | -------------------------------------------------------- | ----------------------------------------------- |
+| `0.1.x`  | `< 2026.4.21`          | `release/0.1.x`  | **Maintenance** — security + critical regressions only    | **Through 2026-10-21** (6 months from 2026.4.21) |
+| `0.2.x`  | `>= 2026.4.21`         | `main`           | **Active** — features, new attributes, new hooks          | Default going forward                           |
+
+After **2026-10-21**, the `release/0.1.x` branch is archived unless the maintainers explicitly accelerate or extend the window (for example, because OpenClaw removes `before_agent_start` earlier than planned).
+
+## What "maintenance" means for `0.1.x`
+
+- **Accepted**: security fixes, critical regressions that break basic plugin operation on supported OpenClaw < `2026.4.21` versions.
+- **Not accepted**: new features, new telemetry attributes, new hooks, refactors, cosmetic changes.
+- **Cherry-picks only**: fixes land on `main` first and are cherry-picked to `release/0.1.x`. See the backport section in [`CONTRIBUTING.md`](CONTRIBUTING.md#backports-to-release01x) for the discipline.
+- **PRs must be labeled `track/0.1`**.
+
+## What "active" means for `0.2.x`
+
+- Runs against **OpenClaw `>= 2026.4.21`**, targeting `before_model_resolve` and `before_prompt_build`.
+- All new work (features, attributes, hook migrations, documentation) lands on `main`.
+- **PRs must be labeled `track/0.2`**.
+
+## Reporting issues
+
+Open a GitHub issue and apply the track label that matches the OpenClaw version you are running:
+
+- OpenClaw **`< 2026.4.21`** → label the issue `track/0.1`.
+- OpenClaw **`>= 2026.4.21`** → label the issue `track/0.2`.
+
+If you are not sure which track applies, open the issue and the maintainers will triage it. For `track/0.1` bug reports after the 2026-10-21 EOL date, we recommend upgrading OpenClaw to `>= 2026.4.21` and the plugin to `0.2.x`.
+
+## Escalation
+
+For a regression that blocks production on `0.1.x` before the EOL date, open a `track/0.1` issue with:
+
+- OpenClaw version (`openclaw --version`).
+- Plugin version (from `openclaw.plugin.json` → `version`).
+- Minimal reproduction and the observed vs expected behavior.
+
+The maintainers review `track/0.1` issues on a best-effort basis through **2026-10-21**.
+
+## Related
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — backport workflow and PR labeling.
+- [`CHANGELOG.md`](CHANGELOG.md) — per-release compatibility notes.


### PR DESCRIPTION
## Summary

Stands up the two-track support policy scaffolding agreed in [ISI-735](/ISI/issues/ISI-735) (parent [ISI-729](/ISI/issues/ISI-729)):

- Add `SUPPORT.md` with the locked policy table, `0.1.x` EOL date (**2026-10-21**), track/0.1 vs track/0.2 escalation paths.
- Add `CONTRIBUTING.md` covering `track/*` PR labels and the cherry-pick-only backport discipline for `release/0.1.x`.
- Add a **Support matrix** section at the top of `README.md` that points at `SUPPORT.md` and `CONTRIBUTING.md`.

## Context

OpenClaw `2026.4.21` shipped the new `before_model_resolve` / `before_prompt_build` hooks and started emitting the `before_agent_start` deprecation warning. ISI-735 wires up the policy scaffolding so:

- `release/0.1.x` (cut at `791fe9b`) can continue to ship maintenance fixes for OpenClaw `< 2026.4.21` through 2026-10-21.
- `main` / `0.2.x` (once PR #16 for ISI-730 merges) becomes the active track on OpenClaw `>= 2026.4.21`.

This PR is intentionally docs-only. The hook migration itself ships in PR #16 / ISI-730.

## Also done on this ticket (out of tree)

- Branch `release/0.1.x` cut at `791fe9b` (current `main` HEAD, i.e., the commit immediately before PR #16 merges).
- GitHub labels `track/0.1` (amber, `< 2026.4.21`, maintenance) and `track/0.2` (green, `>= 2026.4.21`, active) created on this repo.
- Branch protection on `release/0.1.x` still to do — will be requested separately if PAT scope is insufficient.

## Test plan

- [x] `SUPPORT.md`, `CONTRIBUTING.md`, `README.md` render cleanly in GitHub preview.
- [x] Support matrix rows match the locked policy exactly (ranges, branch names, EOL date).
- [x] Cross-links between `README.md` ↔ `SUPPORT.md` ↔ `CONTRIBUTING.md` resolve.
- [ ] Maintainer reviews before merge.

Refs [ISI-735](/ISI/issues/ISI-735), [ISI-729](/ISI/issues/ISI-729); related [ISI-730](/ISI/issues/ISI-730) / PR #16.