### PR TITLE
fix(manifest): align 0.2.0 minOpenClawVersion to 2026.4.21 (ISI-746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed
 
 - **Hook migration (ISI-730).** Replaced the legacy `before_agent_start` hook
-  registration with the phase-specific hooks introduced in OpenClaw 2026.2:
+  registration with the phase-specific hooks introduced in OpenClaw 2026.4.21:
   - `before_model_resolve` — creates the `openclaw.agent.turn` span at the
     earliest point in the agent run. Agent-identity attributes
     (`gen_ai.agent.id`, `gen_ai.conversation.id`, `openclaw.agent.id`,
@@ -48,13 +48,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Removed
 
 - `before_agent_start` hook registration. The plugin no longer listens to
-  this legacy hook. If you run this version against OpenClaw &lt; 2026.2,
+  this legacy hook. If you run this version against OpenClaw &lt; 2026.4.21,
   the agent turn span will not be created. Pin to `0.1.x` if you still
   need the legacy path.
 
 ### Added
 
-- `minOpenClawVersion: 2026.2.0` in `openclaw.plugin.json`.
+- `minOpenClawVersion: 2026.4.21` in `openclaw.plugin.json`.
 - Regression tests for hook wiring (`tests/hooks.test.ts`).
 - `instrumentation/capture-content.mjs` exports `resolveCaptureContent(env)`
   and the `CAPTURE_CONTENT_ENV` constant, consumed by the preload and

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "OpenTelemetry Observability",
   "description": "Traces, metrics, and logs for OpenClaw using OpenLLMetry and OpenTelemetry",
   "version": "0.2.0",
-  "minOpenClawVersion": "2026.2.0",
+  "minOpenClawVersion": "2026.4.21",
   "uiHints": {
     "endpoint": {
       "label": "OTLP Endpoint",


### PR DESCRIPTION
## Summary

Hotfix on `main` to resolve a three-way inconsistency between the plugin manifest, the `0.2.0` CHANGELOG entry, and `SUPPORT.md`.

PR #16 merged the hook migration (ISI-730) and the CHANGELOG referenced OpenClaw `2026.2` as the minimum. The board-locked support policy in `SUPPORT.md` (shipped in PR #18, ISI-735) declares that `0.2.x` requires OpenClaw `>= 2026.4.21` — the release that introduced `before_model_resolve` and `before_prompt_build` and deprecated `before_agent_start`. `SUPPORT.md` is the canonical source per the CEO direction on 2026-04-23.

This PR aligns the manifest and the `[0.2.0]` CHANGELOG entry to `2026.4.21`.

### Changes

- `openclaw.plugin.json`: `minOpenClawVersion` `2026.2.0` → `2026.4.21`.
- `CHANGELOG.md` `[0.2.0]` entry:
  - `introduced in OpenClaw 2026.2` → `introduced in OpenClaw 2026.4.21`.
  - `OpenClaw < 2026.2` → `OpenClaw < 2026.4.21`.
  - `minOpenClawVersion: 2026.2.0` → `minOpenClawVersion: 2026.4.21`.

### Out of scope

- `src/` code logic — no behavioral changes.
- Backports to `release/0.1.x`.
- Other `2026.2` references outside the `[0.2.0]` CHANGELOG section (e.g. `README.md`, `docs/getting-started.md`, `docs/index.md`, `docs/telemetry/traces.md`, `src/hooks.ts`). Those are general OpenClaw product references, not the plugin minimum version, and are left for a separate cleanup if desired.

### Refs

- Parent: [ISI-729](/ISI/issues/ISI-729) (plugin compatibility).
- Hook migration that introduced the boundary: [ISI-730](/ISI/issues/ISI-730) (PR #16).
- Support policy (canonical source): [ISI-735](/ISI/issues/ISI-735) (PR #18 — `SUPPORT.md`).
- This ticket: [ISI-748](/ISI/issues/ISI-748).

### Follow-up

After merge, ISI-748 Part 2 cuts the `v0.2.0` tag and GitHub Release at the merge commit and flips Latest from v0.1.0 to v0.2.0.