### PR TITLE
docs: document hooks.allowConversationAccess requirement (ISI-945, #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the `@openclaw/otel-observability` plugin are documented 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Document the `hooks.allowConversationAccess: true` requirement (ISI-945,
+  github issue [#20](https://github.com/henrikrexed/openclaw-observability-plugin/issues/20)).**
+  OpenClaw 2026.4.23 introduced a typed-hook policy gate: non-bundled
+  (path-loaded) plugins must explicitly opt in to the conversation hooks
+  (`before_model_resolve`, `before_agent_reply`, `llm_input`, `llm_output`,
+  `before_agent_finalize`, `agent_end`, `before_agent_run`) by setting
+  `plugins.entries.<plugin-id>.hooks.allowConversationAccess: true` on their
+  entry. Without it the runtime silently drops those registrations — the
+  plugin's `[otel] Registered ... hook (via api.on)` banners still print but
+  the handlers never fire, so no `openclaw.request` / `openclaw.agent.turn`
+  spans reach the backend even though the metric heartbeat keeps emitting.
+  README install snippets, `docs/getting-started.md`, and the
+  README troubleshooting section now document the requirement and the
+  `pluginDiagnostics` block warning to look for.
+
 ## [0.3.0] — 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -160,12 +160,17 @@ OpenClaw has two hook registration moments, and the plugin uses both at the righ
        },
        "entries": {
          "otel-observability": {
-           "enabled": true
+           "enabled": true,
+           "hooks": {
+             "allowConversationAccess": true
+           }
          }
        }
      }
    }
    ```
+
+   > **Required for OpenClaw ≥ 2026.4.23.** The runtime silently blocks the conversation typed hooks (`before_model_resolve`, `llm_input`, `llm_output`, `before_agent_finalize`, `agent_end`, `before_agent_reply`, `before_agent_run`) for non-bundled (path-loaded) plugins unless `hooks.allowConversationAccess: true` is set on the entry. Without it, the registration banners still print but `openclaw.request` / `openclaw.agent.turn` spans never reach your backend. See [Troubleshooting → Hooks register but never fire](#hooks-register-but-never-fire) and [github issue #20](https://github.com/henrikrexed/openclaw-observability-plugin/issues/20).
 
 3. Clear cache and restart:
    ```bash
@@ -441,13 +446,51 @@ See [Security: Tetragon](./docs/security/tetragon.md) for full installation and 
 
 ### Hooks register but never fire
 
-**Symptom.** The plugin logs `[otel] ✅ Observability pipeline active` at gateway startup, but no `openclaw.request` or `tool.*` spans ever reach your backend — even after you send messages that clearly invoke tools.
+**Symptom.** The plugin logs `[otel] ✅ Observability pipeline active` at gateway startup and prints all the `[otel] Registered ... hook (via api.on)` banners, but no `openclaw.request` or `openclaw.agent.turn` spans ever reach your backend — even after you send messages that clearly invoke tools. The plugin's metrics keep exporting every 30 s with the right resource attributes but every counter stays at `Value: 0.000000` with `openclaw.idle: Bool(true)` (the idle-keepalive heartbeat).
 
-**Cause (pre-PR #6).** Earlier builds registered typed hooks from inside the async `service.start()` phase. OpenClaw snapshots typed hooks at plugin registration time, ~30 s before `start()` runs, so the gateway never saw the 15 hook listeners. See [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6).
+There are two distinct causes that produce the same outward symptom. Check both.
 
-**Fix.** Upgrade to a build that includes PR #6. Hooks are now registered synchronously in `register()` and resolve the telemetry runtime lazily.
+#### Cause A — `hooks.allowConversationAccess` not set (OpenClaw ≥ 2026.4.23)
 
-**How to confirm hooks are live:**
+OpenClaw 2026.4.23 introduced a typed-hook policy gate. The runtime silently drops registrations for the **conversation hooks** — `before_model_resolve`, `before_agent_reply`, `llm_input`, `llm_output`, `before_agent_finalize`, `agent_end`, `before_agent_run` — when the plugin is **non-bundled** (loaded via `plugins.load.paths`, the install path documented in this repo) and the entry does not explicitly opt in. `api.on(...)` returns silently, so the plugin's `[otel] Registered ... hook` banner still prints, but the handler is never wired into the typed-hook registry. The gateway log records the block as a `pluginDiagnostics` warning:
+
+```
+typed hook "agent_end" blocked because non-bundled plugins must set
+plugins.entries.otel-observability.hooks.allowConversationAccess=true
+```
+
+(One line per blocked hook. Look for it under `openclaw plugins list --diagnostics` or in `~/.openclaw/logs/gateway.log`.)
+
+**Fix.** Set the policy on the plugin entry:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing. This setting was added to OpenClaw's plugin-config schema in 2026.4.23 alongside the gate; if you saw `Unrecognized key: "allowConversationAccess"` and a `Config auto-restored from last-known-good` rollback on first attempt, you were briefly on a build between [openclaw#71621](https://github.com/openclaw/openclaw/issues/71621) opening and its same-day fix — upgrade to any 2026.4.24+ release.
+
+**Why this matters here.** The conversation hooks are exactly the ones that anchor the plugin's trace structure: `before_model_resolve` opens the agent turn span, `llm_input`/`llm_output` produce the model-call span, and `agent_end` closes everything. Without them, only the standalone counters (`messagesReceived`, etc.) and the `message_received` root span survive — and even those usually go undetected because the agent never finishes the turn properly. Sibling plugins that **are** bundled in OpenClaw (e.g., `memory-lancedb-pro`) are not affected by the gate, which is why their `agent_end` handler still fires on the same turns.
+
+This is the cause behind [github issue #20](https://github.com/henrikrexed/openclaw-observability-plugin/issues/20) and the most common report on `0.2.x`/`0.3.x` against OpenClaw 2026.4.23 or newer.
+
+#### Cause B — Hooks registered from `start()` instead of `register()` (pre-PR #6)
+
+Earlier builds registered typed hooks from inside the async `service.start()` phase. OpenClaw snapshots typed hooks at plugin registration time, ~30 s before `start()` runs, so the gateway never saw the listeners. See [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6).
+
+**Fix.** Upgrade to a build that includes PR #6 (any `0.2.x` or newer). Hooks are now registered synchronously in `register()` and resolve the telemetry runtime lazily.
+
+#### How to confirm hooks are live
 
 1. Check the gateway log for the registration lines emitted from `register()`:
    ```
@@ -459,16 +502,20 @@ See [Security: Tetragon](./docs/security/tetragon.md) for full installation and 
    [otel] Registered command event hooks (via api.registerHook)
    [otel] Registered gateway:startup hook (via api.registerHook)
    ```
-   If these are **missing**, the plugin is not loaded — check `plugins.load.paths` in `openclaw.json` and clear `/tmp/jiti`.
+   If these are **missing**, the plugin is not loaded — check `plugins.load.paths` in `openclaw.json` and clear `/tmp/jiti`. If they print but spans still never appear, jump to step 2.
 
-2. Send a real message through the pipeline and watch for the per-event debug lines (enable debug logging first):
+2. Look for `pluginDiagnostics` warnings about blocked typed hooks. The presence of any
+   `typed hook "<name>" blocked because non-bundled plugins must set ... allowConversationAccess=true`
+   line is the deterministic signal for **Cause A** above. The registration banner and the block warning can both be present in the same boot — the banner only proves `api.on()` returned, not that the registration was accepted.
+
+3. Send a real message through the pipeline and watch for the per-event debug lines (enable debug logging first):
    ```
    [otel] Root span started for session=<sessionKey>
    [otel] Agent turn span started: agent=<agentId>, session=<sessionKey>
    ```
-   If registration lines are present but these do **not** appear on messages, the hooks are registered but the gateway is not firing them for your event path (e.g., heartbeats and some internal events do not carry full session context).
+   If only the `Root span started` line appears but never `Agent turn span started`, conversation hooks are blocked (Cause A). If neither appears on inbound `/v1/chat/completions` or channel messages, the gateway is not firing typed hooks for your event path (e.g., heartbeats and some internal events do not carry full session context).
 
-3. Verify your OTLP endpoint is actually receiving data:
+4. Verify your OTLP endpoint is actually receiving data:
    ```bash
    curl -v http://localhost:4318/v1/traces
    ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,12 +77,17 @@ Add to your `~/.openclaw/openclaw.json`:
     },
     "entries": {
       "otel-observability": {
-        "enabled": true
+        "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        }
       }
     }
   }
 }
 ```
+
+> **Required for OpenClaw ≥ 2026.4.23.** Path-loaded (non-bundled) plugins must explicitly opt in to conversation typed hooks. Without `hooks.allowConversationAccess: true`, OpenClaw silently drops the registrations for `before_model_resolve`, `llm_input`, `llm_output`, `before_agent_finalize`, `agent_end`, `before_agent_reply`, and `before_agent_run`. The plugin still prints its `[otel] Registered ... hook (via api.on)` banners but the handlers never fire, so no `openclaw.request` / `openclaw.agent.turn` spans reach your backend. See [github issue #20](https://github.com/henrikrexed/openclaw-observability-plugin/issues/20) and the [troubleshooting section](../README.md#hooks-register-but-never-fire).
 
 > **Note:** Do NOT add a `config` block inside `otel-observability` — OpenClaw's plugin framework rejects unknown properties. The plugin reads its settings from the `diagnostics.otel` section instead. If you need custom settings, configure them in `diagnostics.otel` (see Option 1 above).
 
@@ -164,6 +169,9 @@ For complete observability, enable both:
     "entries": {
       "otel-observability": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "endpoint": "http://localhost:4318",
           "serviceName": "openclaw-gateway"
@@ -173,6 +181,8 @@ For complete observability, enable both:
   }
 }
 ```
+
+> `hooks.allowConversationAccess: true` is required on OpenClaw ≥ 2026.4.23. See [the install step above](#step-3-configure-openclaw).
 
 **What you get:**
 


### PR DESCRIPTION
## Summary

Documents the `plugins.entries.<plugin-id>.hooks.allowConversationAccess: true` requirement that resolves [github issue #20](https://github.com/henrikrexed/openclaw-observability-plugin/issues/20). No code changes — readme/docs/changelog only.

## Diagnosis

OpenClaw 2026.4.23 introduced a typed-hook policy gate (added in https://github.com/openclaw/openclaw/issues/71621). The gate silently drops conversation-hook registrations for **non-bundled (path-loaded) plugins** unless the entry explicitly opts in:

- Blocked hooks (per `src/plugins/hook-types.ts` `CONVERSATION_HOOK_NAMES`): `before_model_resolve`, `before_agent_reply`, `llm_input`, `llm_output`, `before_agent_finalize`, `agent_end`, `before_agent_run`.
- Block site (per `src/plugins/registry.ts` `registerTypedHook`): `if (record.origin !== "bundled" && policy?.allowConversationAccess !== true) return;` — pushes a `pluginDiagnostics` warning, drops the registration.

Symptom matches the user's report exactly:
- `[otel] Registered ... hook (via api.on)` banners print (because `api.on` is wired to a registry call that returns silently after the drop).
- The metric heartbeat keeps emitting every 30 s with `openclaw.idle: Bool(true)`.
- No `openclaw.request` / `openclaw.agent.turn` spans, no counter increments.
- Sibling **bundled** plugins (`memory-lancedb-pro`) are unaffected by the gate — that's why their `agent_end` fires on the same turns.

## Changes

- **README** install snippet: add `hooks.allowConversationAccess: true`. Add a callout linking to the troubleshooting section.
- **README** troubleshooting "Hooks register but never fire": split into Cause A (new — this gate, OpenClaw ≥ 2026.4.23) and Cause B (existing — PR #6 / ISI-515). Point operators at the deterministic `pluginDiagnostics` block warning to look for in `~/.openclaw/logs/gateway.log`.
- **docs/getting-started.md**: mirror the requirement on Step 3 install and the "Using Both Plugins Together" example.
- **CHANGELOG.md**: Unreleased entry capturing the doc change.

## Why docs-only

The gate is upstream policy that we cannot bypass from the plugin side. `api.on()` returns void, so we can't detect the drop and warn the operator at runtime. The plugin doesn't see the entry-level `hooks.allowConversationAccess` field either (only the `config` sub-block reaches `register()`). Documentation + a clear troubleshooting recipe is the actionable fix.

## Test plan

- [x] `npm run typecheck` passes.
- [x] `npm test` passes (vitest 53 + 65 + node --test 6 = 118 tests, no regressions — only docs touched).
- [x] DCO sign-off present on commit.
- [ ] Manual verification on OpenClaw 2026.5.3 with the new config snippet — request from the issue reporter once merged.

## Follow-ups out of scope here

- Bumping the README support matrix to flag 0.2.x as broken on OpenClaw ≥ 2026.4.23 without the policy. Worth a separate ISI ticket if `0.2.x` keeps shipping.
- A runtime self-check that surfaces the missing policy. Blocked on plugin-API exposing the entry-level `hooks` config to `register()`. File upstream feature request if we want this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)