### PR TITLE
fix(otel): detect preloaded SDK to avoid double provider registration (ISI-996)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,7 +30,7 @@
  */
 
 import { parseConfig, type OtelObservabilityConfig } from "./src/config.js";
-import { initTelemetry, type TelemetryRuntime } from "./src/telemetry.js";
+import { initTelemetry, hasPreloadedOtelSdk, type TelemetryRuntime } from "./src/telemetry.js";
 import { initOpenLLMetry } from "./src/openllmetry.js";
 import { registerHooks } from "./src/hooks.js";
 import { registerDiagnosticsListener, hasDiagnosticsSupport } from "./src/diagnostics.js";
@@ -151,7 +151,7 @@ const otelObservabilityPlugin = {
         // already active with a mismatched value, LLM-client spans will
         // reflect the preload's value (not the plugin config) — warn so
         // operators know to set the env var before launching the gateway.
-        const preloadActive = (globalThis as any).__OPENCLAW_OTEL_PRELOAD_ACTIVE === true;
+        const preloadActive = hasPreloadedOtelSdk();
         const preloadResolved = (globalThis as any).__OPENCLAW_OTEL_CAPTURE_CONTENT;
         if (preloadActive && preloadResolved !== config.captureContent) {
           logger.warn(

--- a/instrumentation/preload.mjs
+++ b/instrumentation/preload.mjs
@@ -54,6 +54,9 @@ sdk.start();
 
 // Signal to the plugin that preload is active, and publish the resolved
 // traceContent state so the plugin can detect config/env mismatches.
+// The env var survives subprocess forks (NODE_OPTIONS is inherited), while
+// the globalThis flag is kept for backward-compat with same-process callers.
+process.env.OPENCLAW_OTEL_PRELOADED = "1";
 globalThis.__OPENCLAW_OTEL_PRELOAD_ACTIVE = true;
 globalThis.__OPENCLAW_OTEL_CAPTURE_CONTENT = TRACE_CONTENT;
 

--- a/src/openllmetry.ts
+++ b/src/openllmetry.ts
@@ -12,10 +12,10 @@
  */
 
 import type { OtelObservabilityConfig } from "./config.js";
+import { hasPreloadedOtelSdk } from "./telemetry.js";
 
 export async function initOpenLLMetry(_config: OtelObservabilityConfig, logger: any): Promise<void> {
-  // Check if preload instrumentation is active (it sets a global flag)
-  const preloadActive = (globalThis as any).__OPENCLAW_OTEL_PRELOAD_ACTIVE === true;
+  const preloadActive = hasPreloadedOtelSdk();
 
   if (preloadActive) {
     logger.info("[otel] ✅ GenAI instrumentation active via NODE_OPTIONS preload");

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -29,6 +29,27 @@ import {
   OPENCLAW_SCHEMA_VERSION,
 } from "./semconv.js";
 
+/**
+ * Env var set by instrumentation/preload.mjs when OpenClaw is launched with
+ * `NODE_OPTIONS=--import .../preload.mjs`. When set, an OTel SDK is already
+ * registered as the global TracerProvider in this process, and the plugin
+ * MUST NOT register a second one (the second register() silently replaces
+ * the preload's provider, and plugin spans stop reaching the exporter).
+ */
+const PRELOADED_OTEL_SDK_ENV = "OPENCLAW_OTEL_PRELOADED";
+
+/**
+ * Returns true when an OTel SDK has already been registered by the preload.
+ * Checks both the env var (survives subprocess forks via NODE_OPTIONS) and
+ * the legacy globalThis flag set by older preload versions.
+ */
+export function hasPreloadedOtelSdk(): boolean {
+  return (
+    process.env[PRELOADED_OTEL_SDK_ENV] === "1" ||
+    (globalThis as any).__OPENCLAW_OTEL_PRELOAD_ACTIVE === true
+  );
+}
+
 // ── Types ───────────────────────────────────────────────────────────
 
 export interface TelemetryRuntime {
@@ -135,26 +156,35 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
   let tracerProvider: NodeTracerProvider | undefined;
 
   if (config.traces) {
-    const traceExporter =
-      config.protocol === "grpc"
-        ? new OTLPTraceExporterGRPC({ url: traceEndpoint, headers: config.headers })
-        : new OTLPTraceExporterHTTP({ url: traceEndpoint, headers: config.headers });
+    if (hasPreloadedOtelSdk()) {
+      // Preload already registered a global TracerProvider with its own
+      // exporter. Registering a second provider here would silently replace
+      // the preload's, dropping GenAI auto-instrumentation spans. Reuse the
+      // existing global provider — trace.getTracer() below will return a
+      // tracer backed by it.
+      logger.info("[otel] Reusing preloaded OpenTelemetry SDK (skipping plugin TracerProvider registration)");
+    } else {
+      const traceExporter =
+        config.protocol === "grpc"
+          ? new OTLPTraceExporterGRPC({ url: traceEndpoint, headers: config.headers })
+          : new OTLPTraceExporterHTTP({ url: traceEndpoint, headers: config.headers });
 
-    // SDK v2: pass spanProcessors in constructor (addSpanProcessor was removed)
-    tracerProvider = new NodeTracerProvider({
-      resource,
-      spanProcessors: [new BatchSpanProcessor(traceExporter)],
-    });
+      // SDK v2: pass spanProcessors in constructor (addSpanProcessor was removed)
+      tracerProvider = new NodeTracerProvider({
+        resource,
+        spanProcessors: [new BatchSpanProcessor(traceExporter)],
+      });
 
-    // Register the composite W3C TraceContext + Baggage propagator as the
-    // global propagator so HTTP auto-instrumentations (and our exported
-    // injectTraceContext/extractTraceContext helpers) propagate
-    // `traceparent` across service boundaries by default.
-    const propagator = setupGlobalPropagator();
-    tracerProvider.register({ propagator });
+      // Register the composite W3C TraceContext + Baggage propagator as the
+      // global propagator so HTTP auto-instrumentations (and our exported
+      // injectTraceContext/extractTraceContext helpers) propagate
+      // `traceparent` across service boundaries by default.
+      const propagator = setupGlobalPropagator();
+      tracerProvider.register({ propagator });
 
-    logger.info(`[otel] Trace exporter → ${traceEndpoint} (${config.protocol})`);
-    logger.info("[otel] W3C TraceContext + Baggage propagator registered globally");
+      logger.info(`[otel] Trace exporter → ${traceEndpoint} (${config.protocol})`);
+      logger.info("[otel] W3C TraceContext + Baggage propagator registered globally");
+    }
   }
 
   // ── Metrics ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When OpenClaw is launched with `NODE_OPTIONS=--import .../preload.mjs`, the preload script registers an OTel SDK as the global `TracerProvider` before the plugin loads. The plugin was unconditionally registering a second `NodeTracerProvider`, which silently replaced the preload's provider — plugin spans then stopped reaching the configured exporter and GenAI auto-instrumentation spans were lost.

## Changes

- `instrumentation/preload.mjs` now sets `process.env.OPENCLAW_OTEL_PRELOADED = "1"` so child processes spawned by the gateway inherit the signal via `NODE_OPTIONS`.
- `src/telemetry.ts` exports `hasPreloadedOtelSdk()` (checks the env var **and** the legacy `globalThis.__OPENCLAW_OTEL_PRELOAD_ACTIVE` flag for backward-compat) and skips `NodeTracerProvider` creation when a preloaded SDK is detected. The plugin's `trace.getTracer()` then resolves through the preload's already-registered global provider.
- `src/openllmetry.ts` and `index.ts` switched to the shared `hasPreloadedOtelSdk()` helper instead of inspecting `globalThis` directly.

## Verification

- `npm run typecheck` clean.
- `npm test`: 118 / 118 pass (3 vitest suites + 6 node:test preload-helper tests).

Linked Paperclip issue: ISI-996.