### PR TITLE
fix(otel): bring GenAI semconv emission back to registry compliance (ISI-993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to the `@henrikrexed/openclaw-otel-observability` plugin are
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **OpenClaw attribute schema bumped to `1.1.0` (ISI-993).** Three call sites
+  that emitted invalid OpenTelemetry GenAI semantic-convention data are now
+  registry-compliant:
+  - `gen_ai.response.finish_reasons` now emits as `string[]` (it was previously
+    a comma-joined string). Consumers reading the attribute should expect an
+    array on captured spans.
+  - The invalid `gen_ai.operation.name = "cron_executed"` attribute is no
+    longer set on `openclaw.cron.exec` spans; the registry only allows the
+    nine standard values (`chat`, `create_agent`, `embeddings`, `execute_tool`,
+    `generate_content`, `invoke_agent`, `invoke_workflow`, `retrieval`,
+    `text_completion`). Cron context remains available via `openclaw.cron.*`.
+
+### Breaking
+
+- **Tool-approval attributes moved out of the reserved `gen_ai.*` namespace
+  (ISI-993).** The OTel registry reserves `gen_ai.*` for standardised
+  attributes; the plugin's custom approval keys have been renamed to the
+  plugin-domain namespace:
+  - `gen_ai.tool.approval.requested` → `openclaw.tool.approval.requested`
+  - `gen_ai.tool.approval.resolution` → `openclaw.tool.approval.resolution`
+  - `gen_ai.tool.approval.duration_ms` → `openclaw.tool.approval.duration_ms`
+
+  Dashboards or alert rules filtering on the old `gen_ai.tool.approval.*` keys
+  must be updated. `OPENCLAW_SCHEMA_VERSION` is bumped from `1.0.0` to `1.1.0`
+  so consumers can detect the rename.
+
 ## [0.3.1] — 2026-05-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
     `generate_content`, `invoke_agent`, `invoke_workflow`, `retrieval`,
     `text_completion`). Cron context remains available via `openclaw.cron.*`.
 
+### Fixed
+
+- **`gen_ai.response.finish_reasons` array hardening (ISI-993).** Non-string
+  entries (`null`, `undefined`, numbers, empty strings) are now filtered out
+  of the array before the attribute is set. If the array contains no valid
+  strings after filtering, the attribute is omitted entirely. This prevents
+  malformed upstream events from emitting non-spec data via the unchecked
+  TypeScript cast that landed in the initial Story 1 fix.
+
 ### Breaking
 
 - **Tool-approval attributes moved out of the reserved `gen_ai.*` namespace

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ openclaw.request (root span)
 | Log Export Pipeline | OTLP log export via `log.record` diagnostic events with severity, filtering, trace correlation |
 | Security Detection | Prompt injection, dangerous command, sensitive file access detection on spans |
 | GenAI Semantic Conventions | Full stable `gen_ai.*` attributes alongside legacy `openclaw.*` for dashboard compat |
-| Tool Approval Tracking | `gen_ai.tool.approval.requested/resolution/duration_ms` attributes |
+| Tool Approval Tracking | `openclaw.tool.approval.requested/resolution/duration_ms` attributes (schema 1.1.0; renamed from `gen_ai.tool.approval.*`) |
 | Cron & Sub-Agent Monitoring | Spans and metrics for cron jobs and sub-agent orchestration |
 | Diagnostic Integration | Token/cost data from `model.usage` events enriches spans via `onDiagnosticEvent` |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -368,9 +368,9 @@ openclaw.request (root)
 | `gen_ai.request.stream` | Whether streaming |
 | `gen_ai.request.max_tokens` | Max token limit |
 | `gen_ai.provider.name` | Provider name |
-| `gen_ai.tool.approval.requested` | Approval required |
-| `gen_ai.tool.approval.resolution` | Approved/denied |
-| `gen_ai.tool.approval.duration_ms` | Approval wait time |
+| `openclaw.tool.approval.requested` | Approval required (renamed from `gen_ai.tool.approval.requested` in schema 1.1.0) |
+| `openclaw.tool.approval.resolution` | Approved/denied (renamed from `gen_ai.tool.approval.resolution` in schema 1.1.0) |
+| `openclaw.tool.approval.duration_ms` | Approval wait time (renamed from `gen_ai.tool.approval.duration_ms` in schema 1.1.0) |
 | `openclaw.agent.id` | Agent identifier |
 | `openclaw.tool.name` | Tool name |
 | `openclaw.tool.call_id` | Tool call UUID |

--- a/docs/migration-v2-to-v3.md
+++ b/docs/migration-v2-to-v3.md
@@ -39,7 +39,14 @@ V3 emits both GenAI stable attributes (`gen_ai.*`) and legacy attributes (`openc
 - `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`
 - `gen_ai.request.stream`, `gen_ai.request.max_tokens`
 - `gen_ai.provider.name`
-- `gen_ai.tool.approval.requested`, `gen_ai.tool.approval.resolution`, `gen_ai.tool.approval.duration_ms`
+
+> **Schema 1.1.0 (ISI-993) — breaking renames:** the three approval keys formerly under `gen_ai.tool.approval.*` are now plugin-domain attributes:
+>
+> - `gen_ai.tool.approval.requested` → `openclaw.tool.approval.requested`
+> - `gen_ai.tool.approval.resolution` → `openclaw.tool.approval.resolution`
+> - `gen_ai.tool.approval.duration_ms` → `openclaw.tool.approval.duration_ms`
+>
+> Reason: the `gen_ai.*` namespace is reserved for the OTel registry. Dashboards filtering on the old keys must be updated. `gen_ai.response.finish_reasons` is also now emitted as `string[]` (was previously a comma-joined string).
 
 **New openclaw attributes:**
 - `openclaw.session.channel`, `openclaw.session.user_id`, `openclaw.session.duration_ms`
@@ -69,7 +76,7 @@ openclaw.agent.turn
 Tool spans now use `before_tool_call` / `after_tool_call` hooks for accurate timing instead of relying solely on `tool_result_persist`:
 
 - Duration measured from before execution to after completion
-- Tool approval workflow tracking (`gen_ai.tool.approval.*`)
+- Tool approval workflow tracking (`openclaw.tool.approval.*` since schema 1.1.0; previously `gen_ai.tool.approval.*`)
 - Backward compatible: `tool_result_persist` still creates spans when `before_tool_call` didn't fire
 
 ### Session Spans (ISI-928)

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -55,9 +55,9 @@ import {
   GEN_AI_TOKEN_TYPE,
   GEN_AI_TOOL_CALL_ID,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_APPROVAL_REQUESTED,
-  GEN_AI_TOOL_APPROVAL_RESOLUTION,
-  GEN_AI_TOOL_APPROVAL_DURATION_MS,
+  OPENCLAW_TOOL_APPROVAL_REQUESTED,
+  OPENCLAW_TOOL_APPROVAL_RESOLUTION,
+  OPENCLAW_TOOL_APPROVAL_DURATION_MS,
   GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
   GEN_AI_USAGE_CACHE_READ_TOKENS,
@@ -704,9 +704,9 @@ export function registerHooks(
           span.setAttribute(GEN_AI_RESPONSE_ID, responseId);
         }
         if (Array.isArray(finishReasons) && finishReasons.length > 0) {
-          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, finishReasons.join(","));
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, finishReasons as string[]);
         } else if (typeof finishReasons === "string" && finishReasons) {
-          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, finishReasons);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [finishReasons]);
         }
 
         if (inputTokens > 0) {
@@ -913,7 +913,7 @@ export function registerHooks(
         setToolInputPreview(span, toolInput);
 
         if (requiresApproval) {
-          span.setAttribute(GEN_AI_TOOL_APPROVAL_REQUESTED, true);
+          span.setAttribute(OPENCLAW_TOOL_APPROVAL_REQUESTED, true);
           counters.toolApprovals.add(1, {
             [GEN_AI_TOOL_NAME]: toolName,
             [GEN_AI_CONVERSATION_ID]: sessionKey,
@@ -1003,12 +1003,12 @@ export function registerHooks(
 
         const approvalResolution = event?.approvalResolution || event?.approval?.resolution;
         if (approvalRequested && approvalResolution) {
-          span.setAttribute(GEN_AI_TOOL_APPROVAL_RESOLUTION, String(approvalResolution));
+          span.setAttribute(OPENCLAW_TOOL_APPROVAL_RESOLUTION, String(approvalResolution));
           const approvalDurationMs = active.approvalResolvedAt
             ? active.approvalResolvedAt - startTime
             : undefined;
           if (typeof approvalDurationMs === "number") {
-            span.setAttribute(GEN_AI_TOOL_APPROVAL_DURATION_MS, approvalDurationMs);
+            span.setAttribute(OPENCLAW_TOOL_APPROVAL_DURATION_MS, approvalDurationMs);
           }
         }
 
@@ -1051,7 +1051,7 @@ export function registerHooks(
         const active = sessionCtx.activeToolSpans.get(key);
         if (!active) return undefined;
 
-        active.span.setAttribute(GEN_AI_TOOL_APPROVAL_RESOLUTION, String(resolution));
+        active.span.setAttribute(OPENCLAW_TOOL_APPROVAL_RESOLUTION, String(resolution));
         active.span.addEvent("tool.approval.resolved", {
           "tool.approval.resolution": String(resolution),
           "tool.name": toolName,
@@ -1060,7 +1060,7 @@ export function registerHooks(
 
         if (typeof active.startTime === "number") {
           const waitMs = active.approvalResolvedAt - active.startTime;
-          active.span.setAttribute(GEN_AI_TOOL_APPROVAL_DURATION_MS, waitMs);
+          active.span.setAttribute(OPENCLAW_TOOL_APPROVAL_DURATION_MS, waitMs);
         }
 
         logger.debug?.(`[otel] Tool approval resolved: tool=${toolName}, resolution=${resolution}, session=${sessionKey}`);
@@ -1973,7 +1973,6 @@ export function registerHooks(
               [OC_CRON_AGENT_ID]: agentId,
               [GEN_AI_AGENT_ID]: agentId,
               [GEN_AI_PROVIDER_NAME]: provider,
-              [GEN_AI_OPERATION_NAME]: "cron_executed",
               [CODE_FUNCTION]: "cron_executed",
               [CODE_NAMESPACE]: CODE_NS,
             },

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -704,7 +704,12 @@ export function registerHooks(
           span.setAttribute(GEN_AI_RESPONSE_ID, responseId);
         }
         if (Array.isArray(finishReasons) && finishReasons.length > 0) {
-          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, finishReasons as string[]);
+          const cleanReasons = finishReasons.filter(
+            (r): r is string => typeof r === "string" && r.length > 0,
+          );
+          if (cleanReasons.length > 0) {
+            span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, cleanReasons);
+          }
         } else if (typeof finishReasons === "string" && finishReasons) {
           span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [finishReasons]);
         }

--- a/src/semconv.ts
+++ b/src/semconv.ts
@@ -30,9 +30,6 @@ export const GEN_AI_AGENT_NAME = "gen_ai.agent.name";
 export const GEN_AI_TOOL_NAME = "gen_ai.tool.name";
 export const GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id";
 export const GEN_AI_TOOL_TYPE = "gen_ai.tool.type";
-export const GEN_AI_TOOL_APPROVAL_REQUESTED = "gen_ai.tool.approval.requested";
-export const GEN_AI_TOOL_APPROVAL_RESOLUTION = "gen_ai.tool.approval.resolution";
-export const GEN_AI_TOOL_APPROVAL_DURATION_MS = "gen_ai.tool.approval.duration_ms";
 export const GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
 export const GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
 export const GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens";
@@ -81,6 +78,14 @@ export const OC_TOOL_IS_SYNTHETIC = "openclaw.tool.is_synthetic";
 export const OC_TOOL_RESULT_CHARS = "openclaw.tool.result_chars";
 export const OC_TOOL_RESULT_PARTS = "openclaw.tool.result_parts";
 export const OC_TOOL_INPUT_PREVIEW = "openclaw.tool.input_preview";
+/**
+ * Tool-approval attributes live in the plugin-domain namespace because the
+ * OTel `gen_ai.*` namespace is reserved for the registry. Renamed from the
+ * former `gen_ai.tool.approval.*` keys in schema 1.1.0 (breaking change).
+ */
+export const OPENCLAW_TOOL_APPROVAL_REQUESTED = "openclaw.tool.approval.requested";
+export const OPENCLAW_TOOL_APPROVAL_RESOLUTION = "openclaw.tool.approval.resolution";
+export const OPENCLAW_TOOL_APPROVAL_DURATION_MS = "openclaw.tool.approval.duration_ms";
 export const OC_MESSAGE_CHANNEL = "openclaw.message.channel";
 export const OC_MESSAGE_DIRECTION = "openclaw.message.direction";
 export const OC_MESSAGE_FROM = "openclaw.message.from";
@@ -110,7 +115,7 @@ export const OC_CRON_AGENT_ID = "openclaw.cron.agent_id";
  * Schema version for plugin-domain attributes. Bump when emitted
  * attribute keys or values change in a way that consumers need to know.
  */
-export const OPENCLAW_SCHEMA_VERSION = "1.0.0";
+export const OPENCLAW_SCHEMA_VERSION = "1.1.0";
 
 // ── Token type values ───────────────────────────────────────────────
 export const TOKEN_TYPE_INPUT = "input";

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -696,6 +696,68 @@ describe("model_call_started / model_call_ended hooks (ISI-926)", () => {
     stopHooks();
   });
 
+  it("model_call_ended filters non-string entries from finish_reasons (ISI-993 L1)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const modelStarted = typedHooks.get("model_call_started")!;
+    const modelEnded = typedHooks.get("model_call_ended")!;
+
+    resolve({}, { agentId: "a-mixed", sessionKey: "s-mixed" });
+    modelStarted(
+      { sessionKey: "s-mixed", model: "claude-3.5-sonnet", provider: "anthropic" },
+      { sessionKey: "s-mixed" },
+    );
+    modelEnded(
+      {
+        sessionKey: "s-mixed",
+        responseModel: "claude-3.5-sonnet-20241022",
+        finishReasons: ["stop", null, undefined, 42, "", "tool_use"] as unknown as string[],
+      },
+      { sessionKey: "s-mixed" },
+    );
+
+    const chatSpan = spans.find((s) => s.spanName === "chat claude-3.5-sonnet");
+    expect(chatSpan).toBeDefined();
+    const reasons = chatSpan!.attrs["gen_ai.response.finish_reasons"];
+    expect(Array.isArray(reasons)).toBe(true);
+    expect(reasons).toEqual(["stop", "tool_use"]);
+
+    stopHooks();
+  });
+
+  it("model_call_ended omits finish_reasons when all entries are invalid (ISI-993 L1)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const modelStarted = typedHooks.get("model_call_started")!;
+    const modelEnded = typedHooks.get("model_call_ended")!;
+
+    resolve({}, { agentId: "a-bad", sessionKey: "s-bad" });
+    modelStarted(
+      { sessionKey: "s-bad", model: "claude-3.5-sonnet", provider: "anthropic" },
+      { sessionKey: "s-bad" },
+    );
+    modelEnded(
+      {
+        sessionKey: "s-bad",
+        responseModel: "claude-3.5-sonnet-20241022",
+        finishReasons: [null, undefined, 42, ""] as unknown as string[],
+      },
+      { sessionKey: "s-bad" },
+    );
+
+    const chatSpan = spans.find((s) => s.spanName === "chat claude-3.5-sonnet");
+    expect(chatSpan).toBeDefined();
+    expect(chatSpan!.attrs["gen_ai.response.finish_reasons"]).toBeUndefined();
+
+    stopHooks();
+  });
+
   it("model_call_ended records error on span when event.error is set", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -649,13 +649,49 @@ describe("model_call_started / model_call_ended hooks (ISI-926)", () => {
     expect(chatSpan).toBeDefined();
     expect(chatSpan!.attrs["gen_ai.response.model"]).toBe("claude-3.5-sonnet-20241022");
     expect(chatSpan!.attrs["gen_ai.response.id"]).toBe("resp-abc123");
-    expect(chatSpan!.attrs["gen_ai.response.finish_reasons"]).toBe("stop");
+    expect(chatSpan!.attrs["gen_ai.response.finish_reasons"]).toEqual(["stop"]);
+    expect(Array.isArray(chatSpan!.attrs["gen_ai.response.finish_reasons"])).toBe(true);
+    expect(typeof chatSpan!.attrs["gen_ai.response.finish_reasons"]).not.toBe("string");
     expect(chatSpan!.attrs["gen_ai.usage.input_tokens"]).toBe(150);
     expect(chatSpan!.attrs["gen_ai.usage.output_tokens"]).toBe(80);
     expect(chatSpan!.attrs["gen_ai.usage.cache_read.input_tokens"]).toBe(100);
     expect(chatSpan!.attrs["gen_ai.usage.cache_creation.input_tokens"]).toBe(20);
     expect(chatSpan!.attrs["gen_ai.usage.total_tokens"]).toBe(290);
     expect(chatSpan!.ended).toBe(true);
+
+    stopHooks();
+  });
+
+  it("model_call_ended emits gen_ai.response.finish_reasons as string[] (ISI-993)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const modelStarted = typedHooks.get("model_call_started")!;
+    const modelEnded = typedHooks.get("model_call_ended")!;
+
+    resolve({}, { agentId: "a-multi", sessionKey: "s-multi" });
+    modelStarted(
+      { sessionKey: "s-multi", model: "claude-3.5-sonnet", provider: "anthropic" },
+      { sessionKey: "s-multi" },
+    );
+    modelEnded(
+      {
+        sessionKey: "s-multi",
+        responseModel: "claude-3.5-sonnet-20241022",
+        finishReasons: ["tool_use", "stop"],
+      },
+      { sessionKey: "s-multi" },
+    );
+
+    const chatSpan = spans.find((s) => s.spanName === "chat claude-3.5-sonnet");
+    expect(chatSpan).toBeDefined();
+    const reasons = chatSpan!.attrs["gen_ai.response.finish_reasons"];
+    expect(Array.isArray(reasons)).toBe(true);
+    expect(reasons).toEqual(["tool_use", "stop"]);
+    expect(typeof reasons).not.toBe("string");
+    expect(reasons).not.toContain(",");
 
     stopHooks();
   });
@@ -920,7 +956,7 @@ describe("before_tool_call / after_tool_call hooks (ISI-927)", () => {
 
     const toolSpan = spans.find((s) => s.spanName === "execute_tool Bash");
     expect(toolSpan).toBeDefined();
-    expect(toolSpan!.attrs["gen_ai.tool.approval.requested"]).toBe(true);
+    expect(toolSpan!.attrs["openclaw.tool.approval.requested"]).toBe(true);
 
     expect(telemetry.counters.toolApprovals.add).toHaveBeenCalledWith(
       1,
@@ -955,8 +991,8 @@ describe("before_tool_call / after_tool_call hooks (ISI-927)", () => {
 
     const toolSpan = spans.find((s) => s.spanName === "execute_tool Bash");
     expect(toolSpan).toBeDefined();
-    expect(toolSpan!.attrs["gen_ai.tool.approval.resolution"]).toBe("approved");
-    expect(toolSpan!.attrs["gen_ai.tool.approval.duration_ms"]).toBeDefined();
+    expect(toolSpan!.attrs["openclaw.tool.approval.resolution"]).toBe("approved");
+    expect(toolSpan!.attrs["openclaw.tool.approval.duration_ms"]).toBeDefined();
 
     stopHooks();
   });
@@ -1926,6 +1962,8 @@ describe("cron_changed / cron_executed hooks (ISI-929)", () => {
     expect(cronSpan!.attrs["gen_ai.agent.id"]).toBe("agent-2");
     expect(cronSpan!.attrs["gen_ai.provider.name"]).toBe("anthropic");
     expect(cronSpan!.attrs["code.function"]).toBe("cron_executed");
+    // ISI-993: `cron_executed` is not a valid OTel gen_ai.operation.name value.
+    expect(cronSpan!.attrs["gen_ai.operation.name"]).toBeUndefined();
     expect(cronSpan!.ended).toBe(true);
 
     expect(telemetry.counters.cronExecutions.add).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

Story 1/3 of epic ISI-992 — the OTel semconv 2026-04 alignment. Three call sites currently emit data the OTel GenAI registry explicitly forbids. This PR brings them back into compliance and bumps `OPENCLAW_SCHEMA_VERSION` from `1.0.0` to `1.1.0`.

### Changes

- **`gen_ai.response.finish_reasons` emits as `string[]`** — previously a comma-joined string. The OTel attribute API accepts `string[]` and serialises correctly across OTLP/proto and OTLP/HTTP.
- **Drop invalid `gen_ai.operation.name = "cron_executed"`** on `openclaw.cron.exec` spans. The registry only permits `chat`, `create_agent`, `embeddings`, `execute_tool`, `generate_content`, `invoke_agent`, `invoke_workflow`, `retrieval`, `text_completion`. Cron context remains via `openclaw.cron.*` (unchanged).
- **Move `gen_ai.tool.approval.*` → `openclaw.tool.approval.*`** — the `gen_ai.*` namespace is reserved for the OTel registry. The three approval constants in `src/semconv.ts` are renamed and all call sites in `src/hooks.ts` follow. **This is a breaking key rename** for any consumer filtering on the old keys; the schema-version bump signals it.

### Acceptance criteria

- [x] `gen_ai.response.finish_reasons` emits as `string[]` on captured spans
- [x] No `gen_ai.operation.name` attribute on `cron_executed` spans (asserted via `toBeUndefined()` test)
- [x] `grep -nR 'gen_ai.tool.approval' src/` returns only a doc comment reference, no emitted attribute keys
- [x] `openclaw.tool.approval.{requested,resolution,duration_ms}` emitted in their place
- [x] `OPENCLAW_SCHEMA_VERSION = "1.1.0"` and noted in `CHANGELOG.md` as Breaking
- [x] `npm test` passes (119 / 119)
- [x] New `ISI-993` test asserts `finish_reasons` is `string[]` (multi-reason case)

### Files touched

- `src/semconv.ts` — constants renamed, schema-version bump, namespace doc comment
- `src/hooks.ts` — finish_reasons array emit; drop invalid cron op-name; rename approval constants at all call sites
- `tests/hooks.test.ts` — assert array shape on finish_reasons; new dedicated multi-reason test; assert cron span has no `gen_ai.operation.name`; update approval-attribute keys
- `CHANGELOG.md` — `[Unreleased]` section with Changed + Breaking
- `docs/architecture.md`, `docs/migration-v2-to-v3.md`, `README.md` — document the rename and array shape

### Test plan

- [x] `npm test` — all 119 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `grep -nR 'gen_ai.tool.approval' src/` returns only the intentional doc comment

Resolves ISI-993. Story 2 (ISI-994 — dual-emit migration) will follow on top of this so the schema bump path stays clean (`1.0.0` → `1.1.0` here → `1.2.0` in Story 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)