### PR TITLE
feat(otel): configurable trace sampling rate (ISI-998)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable trace sampling rate (ISI-998).** New `sampleRate` option
+  (0.0–1.0) in `diagnostics.otel`. When set, the plugin wires a
+  `ParentBasedSampler` around a `TraceIdRatioBasedSampler` so root spans
+  make a deterministic, trace-id-based sampling decision and child spans
+  inherit it — keeping distributed traces coherent under head-based
+  sampling. Invalid values (out of range, `NaN`, non-numeric) are ignored
+  and the SDK default (`parentbased_always_on`) is used. Documented in
+  `docs/configuration.md#trace-sampling`.
+
 ### Changed
 
 - **OpenClaw attribute schema bumped to `1.1.0` (ISI-993).** Three call sites

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ In your backend, look for an `openclaw.request` span with at least one `openclaw
 | `diagnostics.otel.traces` | boolean | true | Enable traces |
 | `diagnostics.otel.metrics` | boolean | true | Enable metrics |
 | `diagnostics.otel.logs` | boolean | false | Enable logs |
-| `diagnostics.otel.sampleRate` | number | 1.0 | Trace sampling (0-1) |
+| `diagnostics.otel.sampleRate` | number | (unset) | Head-based trace sampling rate, 0.0–1.0. Wraps `TraceIdRatioBasedSampler` in `ParentBasedSampler` so child spans inherit the root decision. Omit (or use `1.0`) to keep all traces. |
 
 ### Custom Plugin Options
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,7 +50,7 @@ OpenTelemetry export configuration.
 | `traces` | boolean | `true` | Enable trace export |
 | `metrics` | boolean | `true` | Enable metrics export |
 | `logs` | boolean | `false` | Enable log forwarding |
-| `sampleRate` | number | `1.0` | Trace sampling rate (0.0–1.0) |
+| `sampleRate` | number | — | Trace sampling rate, `0.0`–`1.0`. Omit to use the SDK default (`parentbased_always_on`). See [Trace Sampling](#trace-sampling). |
 | `flushIntervalMs` | number | — | Export flush interval in milliseconds |
 
 ## Endpoint Configuration
@@ -235,6 +235,31 @@ OpenClaw also respects standard OTel environment variables as fallbacks:
 | `OPENCLAW_OTEL_CAPTURE_CONTENT` | `true` to capture LLM prompt/completion text in Traceloop spans. See [captureContent (gateway-launch setting)](#capturecontent-gateway-launch-setting). |
 
 Config file values take precedence over environment variables.
+
+## Trace Sampling
+
+The plugin exports 100% of traces by default. For high-traffic gateways this can be tuned down with the `sampleRate` option (0.0–1.0):
+
+```json
+{
+  "diagnostics": {
+    "otel": {
+      "sampleRate": 0.1
+    }
+  }
+}
+```
+
+Semantics:
+
+- `sampleRate` omitted — the SDK default sampler (`parentbased_always_on`) is used. The plugin does not construct its own sampler; nothing sampler-related appears in the boot log.
+- `sampleRate: 1.0` — the plugin explicitly constructs `ParentBased(TraceIdRatio(1.0))`. Behaviourally equivalent to always-on, but the boot log reports `sampler=parentbased_traceidratio(1)` so operators can confirm the plugin took the sampling code path.
+- `0.0` — drop every trace.
+- Any value in between — keep that fraction of root traces.
+
+Sampling is head-based and parent-respecting: the plugin wires a `ParentBasedSampler` around a `TraceIdRatioBasedSampler`. The root span of a trace makes the sampling decision based on the trace ID; child spans inherit the parent's decision so distributed traces stay coherent and you never see "half a trace".
+
+Invalid values (negative, > 1, `NaN`, non-numeric) are ignored and the SDK default (`parentbased_always_on`) is used instead.
 
 ## `captureContent` (gateway-launch setting)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,13 @@ export interface OtelObservabilityConfig {
   captureContent: boolean;
   /** Metrics export interval in milliseconds */
   metricsIntervalMs: number;
+  /**
+   * Trace sampling rate from 0.0 (drop all) to 1.0 (keep all).
+   * When undefined, the SDK default (AlwaysOn) is used.
+   * Applied via ParentBasedSampler + TraceIdRatioBasedSampler so child
+   * spans honor the root sampling decision (head-based sampling).
+   */
+  sampleRate?: number;
   /** Additional OTel resource attributes */
   resourceAttributes: Record<string, string>;
   /** Optional log pipeline filtering configuration */
@@ -64,6 +71,13 @@ export function parseConfig(raw: unknown): OtelObservabilityConfig {
       typeof obj.metricsIntervalMs === "number" && obj.metricsIntervalMs >= 1000
         ? obj.metricsIntervalMs
         : DEFAULTS.metricsIntervalMs,
+    sampleRate:
+      typeof obj.sampleRate === "number" &&
+      Number.isFinite(obj.sampleRate) &&
+      obj.sampleRate >= 0 &&
+      obj.sampleRate <= 1
+        ? obj.sampleRate
+        : undefined,
     resourceAttributes:
       obj.resourceAttributes &&
       typeof obj.resourceAttributes === "object" &&

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,8 +11,13 @@ import type { Span, Tracer, Meter, Counter, Histogram, UpDownCounter } from "@op
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 
-import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-node";
+import {
+  BatchSpanProcessor,
+  NodeTracerProvider,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} from "@opentelemetry/sdk-trace-node";
+import type { Sampler } from "@opentelemetry/sdk-trace-node";
 import { OTLPTraceExporter as OTLPTraceExporterHTTP } from "@opentelemetry/exporter-trace-otlp-http";
 import { OTLPTraceExporter as OTLPTraceExporterGRPC } from "@opentelemetry/exporter-trace-otlp-grpc";
 
@@ -169,10 +174,25 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
           ? new OTLPTraceExporterGRPC({ url: traceEndpoint, headers: config.headers })
           : new OTLPTraceExporterHTTP({ url: traceEndpoint, headers: config.headers });
 
+      // Head-based sampling: when sampleRate is set, wrap a TraceIdRatioBased
+      // sampler in a ParentBasedSampler so child spans inherit the root
+      // decision and distributed traces stay coherent. When sampleRate is
+      // omitted, omit the `sampler` key entirely so the SDK default
+      // (parentbased_always_on) applies — passing `sampler: undefined`
+      // would silently break if @opentelemetry/core ever stops dropping
+      // undefined keys in its internal merge().
+      let sampler: Sampler | undefined;
+      if (config.sampleRate !== undefined) {
+        sampler = new ParentBasedSampler({
+          root: new TraceIdRatioBasedSampler(config.sampleRate),
+        });
+      }
+
       // SDK v2: pass spanProcessors in constructor (addSpanProcessor was removed)
       tracerProvider = new NodeTracerProvider({
         resource,
         spanProcessors: [new BatchSpanProcessor(traceExporter)],
+        ...(sampler ? { sampler } : {}),
       });
 
       // Register the composite W3C TraceContext + Baggage propagator as the
@@ -182,7 +202,13 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       const propagator = setupGlobalPropagator();
       tracerProvider.register({ propagator });
 
-      logger.info(`[otel] Trace exporter → ${traceEndpoint} (${config.protocol})`);
+      const samplingNote =
+        config.sampleRate !== undefined
+          ? ` sampler=parentbased_traceidratio(${config.sampleRate})`
+          : "";
+      logger.info(
+        `[otel] Trace exporter → ${traceEndpoint} (${config.protocol})${samplingNote}`,
+      );
       logger.info("[otel] W3C TraceContext + Baggage propagator registered globally");
     }
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for `parseConfig` — focuses on validation of new fields.
+ *
+ * ISI-998: sampleRate accepts only finite numbers in [0, 1]; anything else
+ * (out-of-range, NaN, wrong type, missing) yields `undefined` so the plugin
+ * falls back to the SDK default sampler.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { parseConfig } from "../src/config.js";
+
+describe("parseConfig — sampleRate", () => {
+  it("returns undefined when sampleRate is not provided", () => {
+    expect(parseConfig({}).sampleRate).toBeUndefined();
+  });
+
+  it("accepts 0.0 (drop all)", () => {
+    expect(parseConfig({ sampleRate: 0 }).sampleRate).toBe(0);
+  });
+
+  it("accepts 1.0 (keep all)", () => {
+    expect(parseConfig({ sampleRate: 1 }).sampleRate).toBe(1);
+  });
+
+  it("accepts a fractional rate", () => {
+    expect(parseConfig({ sampleRate: 0.25 }).sampleRate).toBe(0.25);
+  });
+
+  it("rejects values above 1", () => {
+    expect(parseConfig({ sampleRate: 1.5 }).sampleRate).toBeUndefined();
+  });
+
+  it("rejects negative values", () => {
+    expect(parseConfig({ sampleRate: -0.1 }).sampleRate).toBeUndefined();
+  });
+
+  it("rejects NaN", () => {
+    expect(parseConfig({ sampleRate: Number.NaN }).sampleRate).toBeUndefined();
+  });
+
+  it("rejects Infinity", () => {
+    expect(
+      parseConfig({ sampleRate: Number.POSITIVE_INFINITY }).sampleRate,
+    ).toBeUndefined();
+  });
+
+  it("rejects non-number types", () => {
+    expect(parseConfig({ sampleRate: "0.5" }).sampleRate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a configurable head-based trace sampling rate for the OpenClaw OTel plugin (ISI-998).

- New `diagnostics.otel.sampleRate` option (0.0–1.0). Default behavior unchanged (keep all traces).
- When set, wires `ParentBasedSampler({ root: TraceIdRatioBasedSampler(rate) })` on the `NodeTracerProvider` so root spans make a deterministic decision based on the trace ID and child spans inherit it — distributed traces stay coherent.
- Invalid values (`<0`, `>1`, `NaN`, `Infinity`, non-number) fall back to the SDK default (keep all).
- Boot log now reports `sampler=parentbased_traceidratio(<rate>)` when sampling is active.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run` — 127 tests pass, including 9 new `parseConfig` cases covering the `sampleRate` validation matrix
- [ ] Manual: run gateway with `sampleRate: 0.1`, confirm boot log shows the sampler note and that downstream backend receives ~10% of traces

Closes ISI-998.