### PR TITLE
feat(otel): W3C trace context propagation (ISI-1001)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,19 @@ import { initOpenLLMetry } from "./src/openllmetry.js";
 import { registerHooks } from "./src/hooks.js";
 import { registerDiagnosticsListener, hasDiagnosticsSupport } from "./src/diagnostics.js";
 
+// ── Public re-exports ───────────────────────────────────────────────
+// W3C trace context propagation helpers. Available without the plugin
+// register lifecycle so user code (custom RPC, message queues,
+// sub-agent transports) can inject/extract `traceparent` directly.
+export {
+  injectTraceContext,
+  extractTraceContext,
+  getPropagator,
+  setupGlobalPropagator,
+  propagationFields,
+  type HeaderCarrier,
+} from "./src/propagation.js";
+
 const otelObservabilityPlugin = {
   id: "otel-observability",
   name: "OpenTelemetry Observability",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^2.0.1",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.203.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.203.0",

--- a/src/propagation.ts
+++ b/src/propagation.ts
@@ -1,0 +1,107 @@
+/**
+ * W3C trace context propagation helpers.
+ *
+ * Registers a composite W3C TraceContext + Baggage propagator as the global
+ * OTel propagator, and exposes inject/extract helpers for plain header
+ * objects (e.g. fetch/Headers carriers, message metadata, sub-agent env).
+ *
+ * Auto-instrumentation libraries (e.g. @opentelemetry/instrumentation-http,
+ * undici, fetch wrappers) pick up the global propagator automatically — so
+ * once the plugin initializes, outgoing HTTP requests from instrumented
+ * client SDKs include `traceparent` / `tracestate` headers without any
+ * additional code.
+ *
+ * Callers that own their own carrier (custom RPC, message queues, child
+ * process env vars) can use {@link injectTraceContext} /
+ * {@link extractTraceContext} directly.
+ */
+
+import { context as otelContext, propagation, type Context, type TextMapGetter, type TextMapSetter } from "@opentelemetry/api";
+import { CompositePropagator, W3CBaggagePropagator, W3CTraceContextPropagator } from "@opentelemetry/core";
+
+/** Plain-object header carrier used by the default helpers. */
+export type HeaderCarrier = Record<string, string | string[] | undefined>;
+
+const setter: TextMapSetter<HeaderCarrier> = {
+  set(carrier, key, value) {
+    carrier[key] = value;
+  },
+};
+
+const getter: TextMapGetter<HeaderCarrier> = {
+  keys(carrier) {
+    return Object.keys(carrier);
+  },
+  get(carrier, key) {
+    if (!carrier) return undefined;
+    const direct = carrier[key];
+    if (direct !== undefined) return direct;
+    const lower = key.toLowerCase();
+    if (carrier[lower] !== undefined) return carrier[lower];
+    for (const k of Object.keys(carrier)) {
+      if (k.toLowerCase() === lower) return carrier[k];
+    }
+    return undefined;
+  },
+};
+
+let cachedPropagator: CompositePropagator | null = null;
+
+/**
+ * Returns the singleton composite W3C propagator
+ * (TraceContext + Baggage). Cheap to call repeatedly.
+ */
+export function getPropagator(): CompositePropagator {
+  if (!cachedPropagator) {
+    cachedPropagator = new CompositePropagator({
+      propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
+    });
+  }
+  return cachedPropagator;
+}
+
+/**
+ * Registers the composite W3C propagator as the OTel global propagator.
+ * Returns the propagator instance for callers that want to attach it to a
+ * `tracerProvider.register({ propagator })` call.
+ *
+ * Safe to call multiple times — subsequent calls are no-ops at the API
+ * level because the global propagator is replaced with the same instance.
+ */
+export function setupGlobalPropagator(): CompositePropagator {
+  const propagator = getPropagator();
+  propagation.setGlobalPropagator(propagator);
+  return propagator;
+}
+
+/**
+ * Inject the current (or supplied) trace context into a header-style
+ * carrier. Sets `traceparent` (and `tracestate` if present) plus W3C
+ * `baggage` when the context carries baggage entries.
+ *
+ * @example
+ *   const headers: Record<string, string> = {};
+ *   injectTraceContext(headers);
+ *   await fetch(url, { headers });
+ */
+export function injectTraceContext(carrier: HeaderCarrier, ctx: Context = otelContext.active()): void {
+  getPropagator().inject(ctx, carrier, setter);
+}
+
+/**
+ * Extract a W3C trace context from a header-style carrier and return a
+ * new {@link Context}. Header lookup is case-insensitive so callers can
+ * pass raw Node `IncomingMessage.headers` directly.
+ *
+ * The returned context can be activated with
+ * `context.with(extracted, () => …)` to make downstream spans children of
+ * the upstream trace.
+ */
+export function extractTraceContext(carrier: HeaderCarrier, ctx: Context = otelContext.active()): Context {
+  return getPropagator().extract(ctx, carrier, getter);
+}
+
+/** Names of the W3C fields the propagator may produce on a carrier. */
+export function propagationFields(): string[] {
+  return getPropagator().fields();
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -21,6 +21,7 @@ import { OTLPMetricExporter as OTLPMetricExporterHTTP } from "@opentelemetry/exp
 import { OTLPMetricExporter as OTLPMetricExporterGRPC } from "@opentelemetry/exporter-metrics-otlp-grpc";
 
 import type { OtelObservabilityConfig } from "./config.js";
+import { setupGlobalPropagator } from "./propagation.js";
 import {
   METRIC_OPERATION_DURATION,
   METRIC_TOKEN_USAGE,
@@ -144,9 +145,16 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       resource,
       spanProcessors: [new BatchSpanProcessor(traceExporter)],
     });
-    tracerProvider.register();
+
+    // Register the composite W3C TraceContext + Baggage propagator as the
+    // global propagator so HTTP auto-instrumentations (and our exported
+    // injectTraceContext/extractTraceContext helpers) propagate
+    // `traceparent` across service boundaries by default.
+    const propagator = setupGlobalPropagator();
+    tracerProvider.register({ propagator });
 
     logger.info(`[otel] Trace exporter → ${traceEndpoint} (${config.protocol})`);
+    logger.info("[otel] W3C TraceContext + Baggage propagator registered globally");
   }
 
   // ── Metrics ─────────────────────────────────────────────────────

--- a/tests/propagation.test.ts
+++ b/tests/propagation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import {
+  context,
+  trace,
+  propagation,
+  ROOT_CONTEXT,
+  type SpanContext,
+} from "@opentelemetry/api";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+
+import {
+  injectTraceContext,
+  extractTraceContext,
+  getPropagator,
+  setupGlobalPropagator,
+  propagationFields,
+} from "../src/propagation.js";
+
+const SAMPLE_SPAN_CONTEXT: SpanContext = {
+  traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+  spanId: "00f067aa0ba902b7",
+  traceFlags: 1,
+  isRemote: false,
+};
+
+describe("W3C trace context propagation", () => {
+  beforeAll(() => {
+    setupGlobalPropagator();
+    const cm = new AsyncLocalStorageContextManager();
+    cm.enable();
+    context.setGlobalContextManager(cm);
+  });
+
+  it("exposes the W3C TraceContext + Baggage propagator fields", () => {
+    const fields = propagationFields();
+    expect(fields).toContain("traceparent");
+    expect(fields).toContain("baggage");
+  });
+
+  it("registers the composite propagator as the OTel global propagator", () => {
+    const installed = setupGlobalPropagator();
+    expect(installed).toBe(getPropagator());
+    // The global API should now produce the same field set.
+    expect(propagation.fields()).toEqual(expect.arrayContaining(["traceparent"]));
+  });
+
+  it("injects a W3C `traceparent` for the active span context", () => {
+    const headers: Record<string, string> = {};
+    const ctxWithSpan = trace.setSpanContext(ROOT_CONTEXT, SAMPLE_SPAN_CONTEXT);
+
+    injectTraceContext(headers, ctxWithSpan);
+
+    expect(typeof headers.traceparent).toBe("string");
+    expect(headers.traceparent).toMatch(
+      /^00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01$/,
+    );
+  });
+
+  it("round-trips through inject -> extract preserving trace + span IDs", () => {
+    const carrier: Record<string, string> = {};
+    const ctxWithSpan = trace.setSpanContext(ROOT_CONTEXT, SAMPLE_SPAN_CONTEXT);
+
+    injectTraceContext(carrier, ctxWithSpan);
+    const extracted = extractTraceContext(carrier);
+    const spanCtx = trace.getSpanContext(extracted);
+
+    expect(spanCtx?.traceId).toBe(SAMPLE_SPAN_CONTEXT.traceId);
+    expect(spanCtx?.spanId).toBe(SAMPLE_SPAN_CONTEXT.spanId);
+    // Remote-extracted contexts must be flagged isRemote=true.
+    expect(spanCtx?.isRemote).toBe(true);
+  });
+
+  it("extracts case-insensitively (Node IncomingMessage.headers style)", () => {
+    const carrier: Record<string, string> = {};
+    const ctxWithSpan = trace.setSpanContext(ROOT_CONTEXT, SAMPLE_SPAN_CONTEXT);
+    injectTraceContext(carrier, ctxWithSpan);
+
+    const upper: Record<string, string> = {};
+    for (const [k, v] of Object.entries(carrier)) {
+      upper[k.toUpperCase()] = v;
+    }
+
+    const extracted = extractTraceContext(upper);
+    const spanCtx = trace.getSpanContext(extracted);
+    expect(spanCtx?.traceId).toBe(SAMPLE_SPAN_CONTEXT.traceId);
+    expect(spanCtx?.spanId).toBe(SAMPLE_SPAN_CONTEXT.spanId);
+  });
+
+  it("returns a context without a span when no traceparent is present", () => {
+    const extracted = extractTraceContext({}, ROOT_CONTEXT);
+    expect(trace.getSpanContext(extracted)).toBeUndefined();
+  });
+
+  it("defaults to the active context when none is supplied to inject", () => {
+    const headers: Record<string, string> = {};
+    const ctxWithSpan = trace.setSpanContext(ROOT_CONTEXT, SAMPLE_SPAN_CONTEXT);
+
+    context.with(ctxWithSpan, () => {
+      injectTraceContext(headers);
+    });
+
+    expect(headers.traceparent).toMatch(/-4bf92f3577b34da6a3ce929d0e0e4736-/);
+  });
+});


### PR DESCRIPTION
## Summary
Resolves [ISI-1001](/ISI/issues/ISI-1001).

- Register composite **W3C TraceContext + Baggage** propagator as the OTel global propagator at telemetry init, so HTTP auto-instrumentations carry `traceparent`/`tracestate` across services.
- Expose `injectTraceContext` / `extractTraceContext` (and `getPropagator` / `setupGlobalPropagator` / `propagationFields`) from the plugin entrypoint for callers with custom carriers (RPC, message queues, sub-agent transports).
- Case-insensitive extraction works directly on Node `IncomingMessage.headers`.

## Files
- `src/propagation.ts` — composite propagator + helpers
- `src/telemetry.ts` — wires propagator into `NodeTracerProvider.register({ propagator })`
- `index.ts` — public re-exports
- `package.json` — promote `@opentelemetry/core` from transitive to explicit dep
- `tests/propagation.test.ts` — 7 tests (round-trip, case-insensitive, default ctx)

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run` — all tests pass (incl. 7 new propagation tests)
- [ ] Manual: outgoing HTTP from an instrumented client now carries `traceparent`