### PR TITLE
fix(otel): harden preloaded SDK detection + unit tests (ISI-1002)

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -36,18 +36,80 @@ import {
  * MUST NOT register a second one (the second register() silently replaces
  * the preload's provider, and plugin spans stop reaching the exporter).
  */
-const PRELOADED_OTEL_SDK_ENV = "OPENCLAW_OTEL_PRELOADED";
+export const PRELOADED_OTEL_SDK_ENV = "OPENCLAW_OTEL_PRELOADED";
 
 /**
- * Returns true when an OTel SDK has already been registered by the preload.
- * Checks both the env var (survives subprocess forks via NODE_OPTIONS) and
- * the legacy globalThis flag set by older preload versions.
+ * Reads the preload hint from env + globalThis without verifying the global
+ * TracerProvider. Exported for tests; production callers should use
+ * {@link hasPreloadedOtelSdk}, which also verifies a real provider is
+ * registered.
  */
-export function hasPreloadedOtelSdk(): boolean {
+export function readPreloadHint(): boolean {
   return (
     process.env[PRELOADED_OTEL_SDK_ENV] === "1" ||
     (globalThis as any).__OPENCLAW_OTEL_PRELOAD_ACTIVE === true
   );
+}
+
+/**
+ * Returns true iff the current global TracerProvider is a real (non-Noop)
+ * provider — i.e. some SDK has called `provider.register()` and the proxy
+ * has a non-Noop delegate, or a non-proxy provider was registered directly.
+ *
+ * Used to defend against env-var-lying scenarios: a child process can inherit
+ * `OPENCLAW_OTEL_PRELOADED=1` while `NODE_OPTIONS` is stripped (sandbox
+ * runners, setuid binaries, `child_process.spawn({env})` overriding the
+ * environment), in which case the preload script never ran and no real
+ * provider exists. Without verification, the plugin would skip its own
+ * registration and silently drop every span as a NOOP.
+ */
+function hasRealGlobalTracerProvider(): boolean {
+  try {
+    const provider = trace.getTracerProvider() as unknown as {
+      getDelegate?: () => unknown;
+    };
+    if (provider == null) return false;
+
+    // ProxyTracerProvider exposes getDelegate(); unset → NoopTracerProvider.
+    if (typeof provider.getDelegate === "function") {
+      const delegate = provider.getDelegate();
+      const ctorName =
+        (delegate as { constructor?: { name?: string } } | null)?.constructor
+          ?.name ?? "";
+      if (delegate == null) return false;
+      if (ctorName === "NoopTracerProvider") return false;
+      if (ctorName === "ProxyTracerProvider") return false;
+      return true;
+    }
+
+    // A non-proxy provider was registered directly — treat as real unless
+    // it's a NoopTracerProvider.
+    const ctorName =
+      (provider as { constructor?: { name?: string } }).constructor?.name ?? "";
+    if (ctorName === "NoopTracerProvider") return false;
+    if (ctorName === "ProxyTracerProvider") return false;
+    return true;
+  } catch {
+    // Be conservative: if we can't verify a real provider, fall through so
+    // the plugin registers its own — better to risk a double-register warning
+    // than to drop every span silently.
+    return false;
+  }
+}
+
+/**
+ * Returns true when an OTel SDK has already been registered by the preload.
+ *
+ * Strategy: treat env/globalThis as a hint, then verify with the OTel API
+ * that a real global TracerProvider is actually registered. Falls through
+ * (returns false) when the hint is set but no real provider exists, so the
+ * plugin will register its own provider and spans always have an exporter.
+ *
+ * @see hasRealGlobalTracerProvider for the verification step.
+ */
+export function hasPreloadedOtelSdk(): boolean {
+  if (!readPreloadHint()) return false;
+  return hasRealGlobalTracerProvider();
 }
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -164,6 +226,17 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       // tracer backed by it.
       logger.info("[otel] Reusing preloaded OpenTelemetry SDK (skipping plugin TracerProvider registration)");
     } else {
+      if (readPreloadHint()) {
+        // Hint says preload was active but no real global TracerProvider is
+        // registered — typically a sandbox that whitelisted env vars but
+        // stripped NODE_OPTIONS, so the preload script never executed.
+        // Register our own provider instead of trusting the lying hint, so
+        // spans still reach the exporter.
+        logger.warn(
+          "[otel] Preload hint set but no global TracerProvider registered — registering plugin provider (NODE_OPTIONS likely stripped)",
+        );
+      }
+
       const traceExporter =
         config.protocol === "grpc"
           ? new OTLPTraceExporterGRPC({ url: traceEndpoint, headers: config.headers })

--- a/tests/preload-detection.test.ts
+++ b/tests/preload-detection.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for `hasPreloadedOtelSdk()` — the gate that decides whether the
+ * plugin registers its own NodeTracerProvider or reuses one already
+ * registered by `instrumentation/preload.mjs`.
+ *
+ * Two concerns are covered:
+ *
+ *  1. The env/globalThis hint is read correctly across the obvious truth
+ *     table (matches the test plan in ISI-1002).
+ *  2. When the hint is set, the helper actually verifies that a real global
+ *     TracerProvider is registered — defends against sandbox runners that
+ *     inherit env vars but strip `NODE_OPTIONS`, in which case the preload
+ *     script never executed and the global provider is still a Noop. If the
+ *     helper trusted the hint blindly there, the plugin would skip its own
+ *     provider registration and silently drop every span.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trace, type TracerProvider } from "@opentelemetry/api";
+
+import {
+  PRELOADED_OTEL_SDK_ENV,
+  hasPreloadedOtelSdk,
+  readPreloadHint,
+} from "../src/telemetry.js";
+
+const GLOBAL_FLAG = "__OPENCLAW_OTEL_PRELOAD_ACTIVE";
+
+function stubRealProvider() {
+  // Pretend a NodeTracerProvider was registered: the global proxy now has a
+  // non-Noop delegate.
+  const fakeRealProvider = {
+    constructor: { name: "NodeTracerProvider" },
+    getTracer: () => ({}) as unknown,
+  };
+  const fakeProxy = {
+    constructor: { name: "ProxyTracerProvider" },
+    getDelegate: () => fakeRealProvider,
+    getTracer: () => ({}) as unknown,
+  };
+  return vi
+    .spyOn(trace, "getTracerProvider")
+    .mockReturnValue(fakeProxy as unknown as TracerProvider);
+}
+
+function stubNoopProxy() {
+  // Default state of the global proxy when no SDK has called register():
+  // getDelegate() returns a NoopTracerProvider sentinel.
+  const noopDelegate = {
+    constructor: { name: "NoopTracerProvider" },
+    getTracer: () => ({}) as unknown,
+  };
+  const fakeProxy = {
+    constructor: { name: "ProxyTracerProvider" },
+    getDelegate: () => noopDelegate,
+    getTracer: () => ({}) as unknown,
+  };
+  return vi
+    .spyOn(trace, "getTracerProvider")
+    .mockReturnValue(fakeProxy as unknown as TracerProvider);
+}
+
+describe("hasPreloadedOtelSdk + readPreloadHint", () => {
+  let savedEnv: string | undefined;
+  let savedFlag: unknown;
+
+  beforeEach(() => {
+    savedEnv = process.env[PRELOADED_OTEL_SDK_ENV];
+    savedFlag = (globalThis as Record<string, unknown>)[GLOBAL_FLAG];
+    delete process.env[PRELOADED_OTEL_SDK_ENV];
+    delete (globalThis as Record<string, unknown>)[GLOBAL_FLAG];
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env[PRELOADED_OTEL_SDK_ENV];
+    } else {
+      process.env[PRELOADED_OTEL_SDK_ENV] = savedEnv;
+    }
+    if (savedFlag === undefined) {
+      delete (globalThis as Record<string, unknown>)[GLOBAL_FLAG];
+    } else {
+      (globalThis as Record<string, unknown>)[GLOBAL_FLAG] = savedFlag;
+    }
+    vi.restoreAllMocks();
+  });
+
+  // ── Hint truth table (M2 baseline) ───────────────────────────────────
+
+  describe("readPreloadHint (pure env/global read)", () => {
+    it('returns true when env var === "1"', () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+      expect(readPreloadHint()).toBe(true);
+    });
+
+    it("returns true when globalThis flag === true (no env var)", () => {
+      (globalThis as Record<string, unknown>)[GLOBAL_FLAG] = true;
+      expect(readPreloadHint()).toBe(true);
+    });
+
+    it("returns false when both env and globalThis are unset", () => {
+      expect(readPreloadHint()).toBe(false);
+    });
+
+    it('returns false when env === "0"', () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "0";
+      expect(readPreloadHint()).toBe(false);
+    });
+
+    it("returns false when env is empty string", () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "";
+      expect(readPreloadHint()).toBe(false);
+    });
+
+    it('returns false when globalThis flag is truthy but not strictly === true', () => {
+      (globalThis as Record<string, unknown>)[GLOBAL_FLAG] = 1;
+      expect(readPreloadHint()).toBe(false);
+    });
+  });
+
+  // ── Hardened helper (M1) ─────────────────────────────────────────────
+
+  describe("hasPreloadedOtelSdk (hint + provider verification)", () => {
+    it("returns false when no hint is set (short-circuits before provider check)", () => {
+      const spy = vi.spyOn(trace, "getTracerProvider");
+      expect(hasPreloadedOtelSdk()).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('returns true when env="1" AND a real TracerProvider is registered', () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+      stubRealProvider();
+      expect(hasPreloadedOtelSdk()).toBe(true);
+    });
+
+    it("returns true when globalThis flag is set AND a real TracerProvider is registered", () => {
+      (globalThis as Record<string, unknown>)[GLOBAL_FLAG] = true;
+      stubRealProvider();
+      expect(hasPreloadedOtelSdk()).toBe(true);
+    });
+
+    it('returns false when env="1" but only a Noop proxy is registered (NODE_OPTIONS stripped)', () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+      stubNoopProxy();
+      expect(hasPreloadedOtelSdk()).toBe(false);
+    });
+
+    it("returns false when globalThis flag is set but only a Noop proxy is registered", () => {
+      (globalThis as Record<string, unknown>)[GLOBAL_FLAG] = true;
+      stubNoopProxy();
+      expect(hasPreloadedOtelSdk()).toBe(false);
+    });
+
+    it('returns false when env="0" regardless of provider state', () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "0";
+      const spy = stubRealProvider();
+      expect(hasPreloadedOtelSdk()).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("returns false when env is empty regardless of provider state", () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "";
+      const spy = stubRealProvider();
+      expect(hasPreloadedOtelSdk()).toBe(false);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("returns false (conservative) when the provider lookup throws", () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+      vi.spyOn(trace, "getTracerProvider").mockImplementation(() => {
+        throw new Error("simulated failure");
+      });
+      expect(hasPreloadedOtelSdk()).toBe(false);
+    });
+
+    it("treats a directly-registered non-proxy non-Noop provider as real", () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+      const direct = {
+        constructor: { name: "NodeTracerProvider" },
+        getTracer: () => ({}) as unknown,
+        // no getDelegate — direct register, not via proxy
+      };
+      vi.spyOn(trace, "getTracerProvider").mockReturnValue(
+        direct as unknown as TracerProvider,
+      );
+      expect(hasPreloadedOtelSdk()).toBe(true);
+    });
+
+    it("treats a directly-registered NoopTracerProvider as not real", () => {
+      process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+      const direct = {
+        constructor: { name: "NoopTracerProvider" },
+        getTracer: () => ({}) as unknown,
+      };
+      vi.spyOn(trace, "getTracerProvider").mockReturnValue(
+        direct as unknown as TracerProvider,
+      );
+      expect(hasPreloadedOtelSdk()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #25 (ISI-996). hasPreloadedOtelSdk() previously trusted the OPENCLAW_OTEL_PRELOADED=1 env var alone, but a child can inherit that env var while NODE_OPTIONS is stripped (sandbox runners, setuid binaries, child_process.spawn({env}) overriding the environment). In that scenario the preload script never executes, no global TracerProvider is registered, the plugin skips its own registration, and trace.getTracer() returns a NOOP tracer - every span is silently dropped.

This PR addresses both soft spots flagged in ISI-1002.

### M1 - harden the helper

- Split env/global read into readPreloadHint() (pure, exported for tests).
- hasPreloadedOtelSdk() now reads the hint, then verifies via trace.getTracerProvider() that a non-NoopTracerProvider delegate is actually registered.
- Falls through (returns false) when the hint lies, so the plugin registers its own provider and spans always reach the exporter.
- initTelemetry() emits a warn log in that path so operators see the NODE_OPTIONS-stripping scenario instead of debugging silent data loss.
- Provider lookup wrapped in try/catch; conservative default false.

### M2 - unit tests for the new helper

tests/preload-detection.test.ts (16 cases):
- readPreloadHint truth table: env=1 / global flag / both unset / env=0 / empty env / truthy-but-not-=== true global.
- hasPreloadedOtelSdk verification: real provider stub returns true, Noop-proxy stub returns false (covered for both env and globalThis hints), short-circuit when hint unset, env=0/empty short-circuit, provider-throws returns false, direct non-proxy provider handling.

### L1 - env-var convention drift

Flagged in the ticket as non-blocking; not changed here. Tech-debt cleanup tracked separately.

## Verification

- npm run typecheck - clean
- npm test - 153/153 vitest (+16 new), 11/11 node:test

## Test plan

- [ ] CI green
- [ ] Reviewer skims src/telemetry.ts hasRealGlobalTracerProvider() logic
- [ ] Reviewer confirms the warn-log message gives operators enough signal

Links: ISI-1002, ISI-996 (PR #25)
