### PR TITLE
chore(otel): drop dual-emitted legacy semconv attrs; schema 1.3.0 (ISI-1004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ## [Unreleased]
 
+### Removed
+
+- **Legacy OTel semconv 2026-04 attributes — dual-emit window closed (ISI-1004).**
+  Schema version bumped to `1.3.0` (resource attribute
+  `openclaw.schema.version`); plugin version bumped to `0.5.0`. The
+  deprecated keys dual-emitted in `1.2.0` (ISI-994) are no longer
+  emitted on spans or metrics:
+
+  | Removed (1.3.0)                       | Stable replacement (already shipped in 1.2.0)                            |
+  | ------------------------------------- | ------------------------------------------------------------------------ |
+  | `gen_ai.system`                       | `gen_ai.provider.name`                                                   |
+  | `code.function` + `code.namespace`    | `code.function.name` + `code.file.path`                                  |
+  | `gen_ai.usage.cache_read_tokens`      | `gen_ai.usage.cache_read.input_tokens`                                   |
+  | `gen_ai.usage.cache_write_tokens`     | `gen_ai.usage.cache_creation.input_tokens`                               |
+  | `gen_ai.usage.total_tokens`           | none — consumers compute `input + output` (per `1.2.0` deprecation note) |
+
+  Affected emit sites: `llm_input`, `llm_output`, `model_call_started`,
+  `model_call_ended`, both `agent_end` safety nets in `src/hooks.ts`; the
+  `model.usage` metric attribute set and `enrichSpanWithUsage` in
+  `src/diagnostics.ts`. Constants exported from `src/semconv.ts` for the
+  removed keys (`GEN_AI_SYSTEM`, `CODE_FUNCTION`, `CODE_NAMESPACE`,
+  `GEN_AI_USAGE_CACHE_READ_TOKENS`, `GEN_AI_USAGE_CACHE_WRITE_TOKENS`,
+  `GEN_AI_USAGE_TOTAL_TOKENS`) are also deleted. The
+  `tests/hooks.test.ts` "ISI-994 dual-emit" describe block is replaced by
+  an "ISI-1004 legacy removal" block that pins the inverse assertions, so
+  any regression that re-introduces a legacy key fails the suite.
+
+  **Consumer action:** dashboards, alerts, and queries must switch to the
+  stable keys before upgrading to plugin `0.5.0` / schema `1.3.0`. See
+  [ISI-994](./docs/architecture.md#deprecated-attributes--dual-emit-window-schema-12x)
+  for the migration history.
+
 ### Added
 
 - **OTel GenAI / code semconv 2026-04 alignment — dual-emit window (ISI-994).**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,7 +268,7 @@ openclaw.request (root)
     │       gen_ai.request.model: "claude-opus-4-5-..."
     │
     ├── chat claude-opus-4-5-20250514 (model call span)
-    │       gen_ai.system: "anthropic"
+    │       gen_ai.provider.name: "anthropic"
     │       gen_ai.request.model: "claude-opus-4-5-..."
     │       gen_ai.response.model: "claude-opus-4-5-20250514"
     │       gen_ai.usage.input_tokens: 1234
@@ -356,7 +356,6 @@ openclaw.request (root)
 | Attribute | Description |
 |-----------|-------------|
 | `gen_ai.operation.name` | Operation: `invoke_agent`, `chat`, `execute_tool` |
-| `gen_ai.system` | LLM provider name — **deprecated**, dual-emitted alongside `gen_ai.provider.name` during schema 1.2.x; removal target `1.3.0` |
 | `gen_ai.request.model` | Requested model name |
 | `gen_ai.response.model` | Actual model used |
 | `gen_ai.response.id` | LLM response ID |
@@ -382,38 +381,38 @@ openclaw.request (root)
 | `openclaw.session.message_count` | History size fed to LLM |
 | `openclaw.dispatch.duration_ms` | Dispatch phase duration |
 
-### Deprecated attributes — dual-emit window (schema 1.2.x)
+### Removed attributes — dual-emit window closed (schema 1.3.0)
 
-Schema `1.2.0` (ISI-994) aligns the plugin with the OTel GenAI / code
-semantic-convention changes published in the 2026-04 registry refresh.
-The legacy keys are **still emitted** alongside the stable replacements
-during a one-minor-release deprecation window so dashboards keyed on
-either form keep working. They will be **removed** in schema `1.3.0`
-(plugin `0.5.0`).
+Schema `1.3.0` (ISI-1004) closes the dual-emit window opened in `1.2.0`
+(ISI-994). The legacy OTel semconv keys are **no longer emitted** —
+dashboards, alerts, and queries must read the stable replacements.
 
-| Legacy attribute | Stable replacement | Where dual-emit lands |
-|------------------|--------------------|-----------------------|
-| `gen_ai.system` | `gen_ai.provider.name` | LLM client span (`llm_input` / `model_call_started`), agent-turn span (via `enrichSpanWithUsage`), and the `model.usage` metric attribute set |
-| `code.function` + `code.namespace` | `code.function.name` (= `${namespace}.${function}`) + `code.file.path` | Every hook-span emit site in `src/hooks.ts` (centralised in the `codeAttrs(funcName)` helper) |
-| `gen_ai.usage.cache_read_tokens` | `gen_ai.usage.cache_read.input_tokens` | `llm_output`, both `agent_end` safety nets, and `enrichSpanWithUsage` |
-| `gen_ai.usage.cache_write_tokens` | `gen_ai.usage.cache_creation.input_tokens` | Same sites as above |
-| `gen_ai.usage.total_tokens` | *(none — compute `input + output`)* | Kept for backward compatibility; marked `@deprecated` in `src/semconv.ts` |
+| Removed (1.3.0)                       | Stable replacement (shipped in 1.2.0)                                    |
+|---------------------------------------|--------------------------------------------------------------------------|
+| `gen_ai.system`                       | `gen_ai.provider.name`                                                   |
+| `code.function` + `code.namespace`    | `code.function.name` (= `${namespace}.${function}`) + `code.file.path`   |
+| `gen_ai.usage.cache_read_tokens`      | `gen_ai.usage.cache_read.input_tokens`                                   |
+| `gen_ai.usage.cache_write_tokens`     | `gen_ai.usage.cache_creation.input_tokens`                               |
+| `gen_ai.usage.total_tokens`           | *(none — compute `input + output`)*                                      |
 
-**Consumer migration checklist (before `1.3.0` ships):**
+The constants that exported the removed keys
+(`GEN_AI_SYSTEM`, `CODE_FUNCTION`, `CODE_NAMESPACE`,
+`GEN_AI_USAGE_CACHE_READ_TOKENS`, `GEN_AI_USAGE_CACHE_WRITE_TOKENS`,
+`GEN_AI_USAGE_TOTAL_TOKENS`) are also removed from `src/semconv.ts`.
 
-- Update Dynatrace dashboards / DQL queries to read
-  `gen_ai.provider.name` instead of `gen_ai.system`.
-- Update queries that filter by `code.function` / `code.namespace` to
-  read `code.function.name` (combined form) or `code.file.path` when a
-  file-level grouping is needed.
-- Switch cache-token panels to the `gen_ai.usage.cache_read.input_tokens`
-  and `gen_ai.usage.cache_creation.input_tokens` keys.
-- Replace any direct reads of `gen_ai.usage.total_tokens` with
-  `gen_ai.usage.input_tokens + gen_ai.usage.output_tokens` so consumers
-  remain accurate after `1.3.0`.
+**Consumer action required:**
 
-The resource attribute `openclaw.schema.version` carries `1.2.0` on
-every signal so consumers can gate their queries on the schema window.
+- Switch Dynatrace dashboards / DQL queries from `gen_ai.system` to
+  `gen_ai.provider.name`.
+- Replace any filter on `code.function` / `code.namespace` with
+  `code.function.name` (combined form) or `code.file.path`.
+- Update cache-token panels to `gen_ai.usage.cache_read.input_tokens` /
+  `gen_ai.usage.cache_creation.input_tokens`.
+- Compute totals as `gen_ai.usage.input_tokens +
+  gen_ai.usage.output_tokens` — `gen_ai.usage.total_tokens` is gone.
+
+The resource attribute `openclaw.schema.version` now carries `1.3.0` on
+every signal so consumers can gate queries on the schema cut-over.
 
 ---
 

--- a/docs/migration-v2-to-v3.md
+++ b/docs/migration-v2-to-v3.md
@@ -33,12 +33,11 @@ If you were relying on `before_agent_start` timing for custom integrations, upda
 V3 emits both GenAI stable attributes (`gen_ai.*`) and legacy attributes (`openclaw.*`) for backward compatibility. New attributes:
 
 **GenAI stable:**
-- `gen_ai.system`, `gen_ai.operation.name`, `gen_ai.request.model`
+- `gen_ai.provider.name`, `gen_ai.operation.name`, `gen_ai.request.model`
 - `gen_ai.response.model`, `gen_ai.response.id`, `gen_ai.response.finish_reasons`
 - `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
 - `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`
 - `gen_ai.request.stream`, `gen_ai.request.max_tokens`
-- `gen_ai.provider.name`
 
 > **Schema 1.1.0 (ISI-993) — breaking renames:** the three approval keys formerly under `gen_ai.tool.approval.*` are now plugin-domain attributes:
 >
@@ -48,17 +47,17 @@ V3 emits both GenAI stable attributes (`gen_ai.*`) and legacy attributes (`openc
 >
 > Reason: the `gen_ai.*` namespace is reserved for the OTel registry. Dashboards filtering on the old keys must be updated. `gen_ai.response.finish_reasons` is also now emitted as `string[]` (was previously a comma-joined string).
 
-> **Schema 1.2.0 (ISI-994) — OTel GenAI / code semconv 2026-04 dual-emit window.** Spans and metrics that previously emitted deprecated attribute keys now also emit the stable replacements alongside the legacy ones for one minor release (planned removal at schema `1.3.0` / plugin `0.5.0`):
+> **Schema 1.2.0 (ISI-994) — OTel GenAI / code semconv 2026-04 dual-emit window.** One-minor-release dual-emit shipped both legacy and stable forms so dashboards keyed on either could keep working during the migration. **Schema 1.3.0 (ISI-1004) closed that window** — the legacy keys are no longer emitted:
 >
-> | Legacy attribute | Stable replacement |
-> |------------------|--------------------|
+> | Removed in 1.3.0 | Stable replacement (use this) |
+> |------------------|-------------------------------|
 > | `gen_ai.system` | `gen_ai.provider.name` |
 > | `code.function` + `code.namespace` | `code.function.name` (= `${namespace}.${function}`) + `code.file.path` |
 > | `gen_ai.usage.cache_read_tokens` | `gen_ai.usage.cache_read.input_tokens` |
 > | `gen_ai.usage.cache_write_tokens` | `gen_ai.usage.cache_creation.input_tokens` |
-> | `gen_ai.usage.total_tokens` | *(none — compute `input + output`)* — kept, marked `@deprecated` |
+> | `gen_ai.usage.total_tokens` | *(none — compute `input + output`)* |
 >
-> Update dashboards / DQL queries to the stable form before the plugin moves to `1.3.0`. The full migration table and consumer checklist live in [`docs/architecture.md`](./architecture.md#deprecated-attributes--dual-emit-window-schema-12x). The resource attribute `openclaw.schema.version` carries `1.2.0` on every signal so consumers can gate queries on the schema window.
+> Dashboards / DQL queries must read the stable keys. The full removal note and consumer checklist live in [`docs/architecture.md`](./architecture.md#removed-attributes--dual-emit-window-closed-schema-130). The resource attribute `openclaw.schema.version` now carries `1.3.0` on every signal.
 
 **New openclaw attributes:**
 - `openclaw.session.channel`, `openclaw.session.user_id`, `openclaw.session.duration_ms`

--- a/docs/telemetry/tokens.md
+++ b/docs/telemetry/tokens.md
@@ -138,10 +138,10 @@ Without caching, the same request would cost:
 
 You might notice:
 ```
-cache_read + cache_write + input + output = 998,598
+cache_read + cache_write + input + output ≠ a backend's reported total
 ```
 
-The `total_tokens` is the sum of all types. Some backends may calculate it differently or include additional overhead tokens.
+Adding `cache_read.input_tokens` + `cache_creation.input_tokens` + `input_tokens` + `output_tokens` may not equal a backend's reported total — different backends count overhead tokens differently. As of schema `1.3.0`, OpenClaw no longer emits `gen_ai.usage.total_tokens`; compute it as `gen_ai.usage.input_tokens + gen_ai.usage.output_tokens` on the consumer side.
 
 ## Optimizing Token Usage
 

--- a/docs/telemetry/tokens.md
+++ b/docs/telemetry/tokens.md
@@ -8,9 +8,15 @@ Understanding the GenAI token usage attributes in OpenClaw observability.
 |-----------|-------------|-------------|
 | `gen_ai.usage.input_tokens` | Tokens in the prompt sent to the model | Standard input rate |
 | `gen_ai.usage.output_tokens` | Tokens in the model's response | Higher rate (typically 3-5x input) |
-| `gen_ai.usage.cache_read_tokens` | Tokens read from prompt cache | **90% cheaper** than input |
-| `gen_ai.usage.cache_write_tokens` | Tokens written to prompt cache | **25% more expensive** than input |
-| `gen_ai.usage.total_tokens` | Sum of all token types | — |
+| `gen_ai.usage.cache_read.input_tokens` | Tokens read from prompt cache | **90% cheaper** than input |
+| `gen_ai.usage.cache_creation.input_tokens` | Tokens written to prompt cache | **25% more expensive** than input |
+
+> Schema `1.3.0` (ISI-1004) removed the legacy
+> `gen_ai.usage.cache_read_tokens` / `gen_ai.usage.cache_write_tokens` /
+> `gen_ai.usage.total_tokens` keys. Total tokens are now computed as
+> `gen_ai.usage.input_tokens + gen_ai.usage.output_tokens`; cache reads /
+> writes use the stable `cache_read.input_tokens` /
+> `cache_creation.input_tokens` keys.
 
 ## How Tokens Are Calculated
 

--- a/docs/telemetry/traces.md
+++ b/docs/telemetry/traces.md
@@ -11,7 +11,6 @@ openclaw.request (SERVER span — full message lifecycle)
 ├── openclaw.agent.turn (INTERNAL — LLM processing)
 │   ├── gen_ai.usage.input_tokens: 4521
 │   ├── gen_ai.usage.output_tokens: 892
-│   ├── gen_ai.usage.total_tokens: 5413
 │   ├── gen_ai.response.model: claude-opus-4-5
 │   ├── tool.exec (INTERNAL — 156ms)
 │   ├── tool.Read (INTERNAL — 12ms)
@@ -67,8 +66,10 @@ See [CHANGELOG](../../CHANGELOG.md) and ISI-730 for the migration details.
 | `openclaw.agent.error` | string | Error message (if failed) |
 | `gen_ai.usage.input_tokens` | int | Total input tokens (including cache read/write) |
 | `gen_ai.usage.output_tokens` | int | Total output tokens |
-| `gen_ai.usage.total_tokens` | int | Sum of input + output tokens |
 | `gen_ai.response.model` | string | Actual model used (from last assistant message) |
+
+> Schema `1.3.0` (ISI-1004) removed `gen_ai.usage.total_tokens` — compute
+> it as `gen_ai.usage.input_tokens + gen_ai.usage.output_tokens`.
 
 !!! note "`gen_ai.request.model` on the turn span"
     The agent turn span no longer carries `gen_ai.request.model` — in
@@ -149,7 +150,8 @@ Stale contexts (no `agent_end` within 5 minutes) are automatically cleaned up.
 fetch spans, samplingRatio:1
 | filter contains(endpoint.name, "openclaw.agent.turn")
 | fields start_time, duration, gen_ai.usage.input_tokens,
-         gen_ai.usage.output_tokens, gen_ai.usage.total_tokens,
+         gen_ai.usage.output_tokens,
+         total_tokens = toLong(gen_ai.usage.input_tokens) + toLong(gen_ai.usage.output_tokens),
          gen_ai.response.model
 | sort start_time desc
 | limit 20

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "otel-observability",
   "name": "OpenTelemetry Observability",
   "description": "Traces, metrics, and logs for OpenClaw using OpenLLMetry and OpenTelemetry",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "minOpenClawVersion": "2026.4.21",
   "uiHints": {
     "endpoint": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@henrikrexed/openclaw-otel-observability",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "description": "OpenTelemetry observability plugin for OpenClaw — traces, metrics, and logs for your AI agent using OpenLLMetry",
   "type": "module",
   "openclaw": {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -14,15 +14,11 @@ import {
   GEN_AI_OPERATION_NAME,
   GEN_AI_PROVIDER_NAME,
   GEN_AI_RESPONSE_MODEL,
-  GEN_AI_SYSTEM,
   GEN_AI_TOKEN_TYPE,
   GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-  GEN_AI_USAGE_CACHE_READ_TOKENS,
-  GEN_AI_USAGE_CACHE_WRITE_TOKENS,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
-  GEN_AI_USAGE_TOTAL_TOKENS,
   OP_INVOKE_AGENT,
   OC_PROVIDER,
   TOKEN_TYPE_INPUT,
@@ -109,12 +105,10 @@ export async function registerDiagnosticsListener(
     });
 
     // Record metrics immediately (don't wait for span).
-    // Use stable GenAI attribute keys; keep openclaw.* mirrors for dashboards.
-    // Dual-emit gen_ai.system (legacy) + gen_ai.provider.name during the
-    // schema 1.2.x deprecation window so dashboards on either key still work.
+    // Stable GenAI attribute keys only — `gen_ai.system` dropped in schema
+    // 1.3.0 (ISI-1004). `openclaw.provider` (legacy mirror) is retained.
     const metricAttrs = {
       [GEN_AI_RESPONSE_MODEL]: model,
-      [GEN_AI_SYSTEM]: provider,
       [GEN_AI_PROVIDER_NAME]: provider,
       [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
       [GEN_AI_CONVERSATION_ID]: sessionKey,
@@ -193,24 +187,19 @@ export function getPendingUsage(sessionKey: string): PendingUsageData | undefine
 export function enrichSpanWithUsage(span: Span, data: PendingUsageData): void {
   const usage = data.usage || {};
 
-  // GenAI semantic convention attributes
+  // GenAI semantic convention attributes — stable keys only.
+  // `gen_ai.usage.total_tokens` and `gen_ai.usage.cache_*_tokens` (legacy)
+  // dropped in schema 1.3.0 (ISI-1004).
   if (usage.input !== undefined) {
     span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, usage.input);
   }
   if (usage.output !== undefined) {
     span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, usage.output);
   }
-  if (usage.total !== undefined) {
-    span.setAttribute(GEN_AI_USAGE_TOTAL_TOKENS, usage.total);
-  }
-  // Dual-emit legacy (`cache_*_tokens`) + stable (`cache_*.input_tokens`)
-  // forms during the schema 1.2.x deprecation window.
   if (usage.cacheRead !== undefined) {
-    span.setAttribute(GEN_AI_USAGE_CACHE_READ_TOKENS, usage.cacheRead);
     span.setAttribute(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, usage.cacheRead);
   }
   if (usage.cacheWrite !== undefined) {
-    span.setAttribute(GEN_AI_USAGE_CACHE_WRITE_TOKENS, usage.cacheWrite);
     span.setAttribute(GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, usage.cacheWrite);
   }
 
@@ -227,10 +216,9 @@ export function enrichSpanWithUsage(span: Span, data: PendingUsageData): void {
     span.setAttribute("openclaw.context.used", data.context.used);
   }
 
-  // Provider/model — dual-emit gen_ai.system (legacy) + gen_ai.provider.name
-  // during the schema 1.2.x deprecation window.
+  // Provider/model — `gen_ai.provider.name` only (legacy `gen_ai.system`
+  // dropped in schema 1.3.0 / ISI-1004).
   if (data.provider) {
-    span.setAttribute(GEN_AI_SYSTEM, data.provider);
     span.setAttribute(GEN_AI_PROVIDER_NAME, data.provider);
   }
   if (data.model) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -57,7 +57,6 @@ import {
   GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_RESPONSE_ID,
   GEN_AI_RESPONSE_MODEL,
-  GEN_AI_SYSTEM,
   GEN_AI_TOKEN_TYPE,
   GEN_AI_TOOL_CALL_ID,
   GEN_AI_TOOL_NAME,
@@ -66,18 +65,13 @@ import {
   OPENCLAW_TOOL_APPROVAL_DURATION_MS,
   GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
-  GEN_AI_USAGE_CACHE_READ_TOKENS,
-  GEN_AI_USAGE_CACHE_WRITE_TOKENS,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
-  GEN_AI_USAGE_TOTAL_TOKENS,
   OP_CHAT,
   OP_EXECUTE_TOOL,
   OP_INVOKE_AGENT,
   TOKEN_TYPE_INPUT,
   TOKEN_TYPE_OUTPUT,
-  CODE_FUNCTION,
-  CODE_NAMESPACE,
   CODE_FUNCTION_NAME,
   CODE_FILE_PATH,
   ERROR_TYPE,
@@ -104,20 +98,17 @@ const CODE_NS = "openclaw.otel.hooks";
 const CODE_FILE = "src/hooks.ts";
 
 /**
- * Dual-emits legacy (`code.function` / `code.namespace`) and stable
- * (`code.function.name` / `code.file.path`) attributes for a hook span.
- * Spread the result into the span `attributes` block.
+ * Emits the stable OTel `code.function.name` + `code.file.path` attributes
+ * for a hook span. Spread the result into the span `attributes` block.
  *
  * `filePath` defaults to this module's `CODE_FILE`; callers from other
  * modules MUST pass their own path so `code.file.path` does not lie.
  *
- * Centralised so the deprecation window can be closed in one place
- * (schema `1.3.0`) by dropping the legacy keys from this helper.
+ * The legacy `code.function` / `code.namespace` keys were dropped in
+ * schema `1.3.0` (ISI-1004) after the dual-emit window opened in `1.2.0`.
  */
 function codeAttrs(funcName: string, filePath: string = CODE_FILE): Record<string, string> {
   return {
-    [CODE_FUNCTION]: funcName,
-    [CODE_NAMESPACE]: CODE_NS,
     [CODE_FUNCTION_NAME]: `${CODE_NS}.${funcName}`,
     [CODE_FILE_PATH]: filePath,
   };
@@ -622,10 +613,7 @@ export function registerHooks(
           {
             kind: SpanKind.CLIENT,
             attributes: {
-              // GenAI stable — dual-emit gen_ai.system (legacy) + gen_ai.provider.name
-              // for the schema 1.2.x deprecation window.
               [GEN_AI_OPERATION_NAME]: OP_CHAT,
-              [GEN_AI_SYSTEM]: provider,
               [GEN_AI_PROVIDER_NAME]: provider,
               [GEN_AI_REQUEST_MODEL]: model,
               [GEN_AI_CONVERSATION_ID]: sessionKey,
@@ -687,8 +675,6 @@ export function registerHooks(
           usage.output ?? usage.outputTokens ?? usage.output_tokens ?? 0;
         const cacheRead = usage.cacheRead ?? usage.cache_read_tokens ?? 0;
         const cacheWrite = usage.cacheWrite ?? usage.cache_write_tokens ?? 0;
-        const totalTokens =
-          usage.total ?? inputTokens + outputTokens + cacheRead + cacheWrite;
 
         llmSpan.setAttribute(GEN_AI_RESPONSE_MODEL, responseModel);
         if (inputTokens > 0) {
@@ -697,18 +683,13 @@ export function registerHooks(
         if (outputTokens > 0) {
           llmSpan.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
         }
-        // Dual-emit legacy (`cache_*_tokens`) + stable (`cache_*.input_tokens`)
-        // forms during the schema 1.2.x deprecation window.
+        // Stable `cache_*.input_tokens` only (legacy `cache_*_tokens` and
+        // `gen_ai.usage.total_tokens` dropped in schema 1.3.0 / ISI-1004).
         if (cacheRead > 0) {
-          llmSpan.setAttribute(GEN_AI_USAGE_CACHE_READ_TOKENS, cacheRead);
           llmSpan.setAttribute(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, cacheRead);
         }
         if (cacheWrite > 0) {
-          llmSpan.setAttribute(GEN_AI_USAGE_CACHE_WRITE_TOKENS, cacheWrite);
           llmSpan.setAttribute(GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, cacheWrite);
-        }
-        if (totalTokens > 0) {
-          llmSpan.setAttribute(GEN_AI_USAGE_TOTAL_TOKENS, totalTokens);
         }
 
         const durationMs =
@@ -775,7 +756,6 @@ export function registerHooks(
             kind: SpanKind.CLIENT,
             attributes: {
               [GEN_AI_OPERATION_NAME]: OP_CHAT,
-              [GEN_AI_SYSTEM]: provider,
               [GEN_AI_PROVIDER_NAME]: provider,
               [GEN_AI_REQUEST_MODEL]: model,
               [GEN_AI_CONVERSATION_ID]: sessionKey,
@@ -848,11 +828,6 @@ export function registerHooks(
           usage.cacheReadInputTokens ?? usage.cache_read_input_tokens ?? 0;
         const cacheCreationInputTokens =
           usage.cacheCreationInputTokens ?? usage.cache_creation_input_tokens ?? 0;
-        const cacheRead = usage.cacheRead ?? usage.cache_read_tokens ?? 0;
-        const cacheWrite = usage.cacheWrite ?? usage.cache_write_tokens ?? 0;
-        const totalTokens =
-          usage.total ?? inputTokens + outputTokens + cacheRead + cacheWrite;
-
         span.setAttribute(GEN_AI_RESPONSE_MODEL, responseModel);
         if (typeof responseId === "string" && responseId) {
           span.setAttribute(GEN_AI_RESPONSE_ID, responseId);
@@ -879,9 +854,6 @@ export function registerHooks(
         }
         if (cacheCreationInputTokens > 0) {
           span.setAttribute(GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, cacheCreationInputTokens);
-        }
-        if (totalTokens > 0) {
-          span.setAttribute(GEN_AI_USAGE_TOTAL_TOKENS, totalTokens);
         }
 
         const durationMs =
@@ -1705,16 +1677,15 @@ export function registerHooks(
             if (totalOutputTokens > 0) {
               sessionCtx.llmSpan.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, totalOutputTokens);
             }
-            // Dual-emit legacy + stable cache attribute forms.
+            // Stable `cache_*.input_tokens` only — legacy keys dropped in
+            // schema 1.3.0 (ISI-1004).
             if (cacheReadTokens > 0) {
-              sessionCtx.llmSpan.setAttribute(GEN_AI_USAGE_CACHE_READ_TOKENS, cacheReadTokens);
               sessionCtx.llmSpan.setAttribute(
                 GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
                 cacheReadTokens,
               );
             }
             if (cacheWriteTokens > 0) {
-              sessionCtx.llmSpan.setAttribute(GEN_AI_USAGE_CACHE_WRITE_TOKENS, cacheWriteTokens);
               sessionCtx.llmSpan.setAttribute(
                 GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
                 cacheWriteTokens,
@@ -1771,10 +1742,11 @@ export function registerHooks(
             agentSpan.setAttribute("openclaw.agent.duration_ms", durationMs);
           }
 
-          // Token usage — GenAI semantic convention attributes
+          // Token usage — stable GenAI semconv attributes only.
+          // `gen_ai.usage.total_tokens` dropped in schema 1.3.0 (ISI-1004);
+          // consumers compute `input + output` themselves.
           agentSpan.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, totalInputTokens);
           agentSpan.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, totalOutputTokens);
-          agentSpan.setAttribute(GEN_AI_USAGE_TOTAL_TOKENS, totalTokens);
           agentSpan.setAttribute(GEN_AI_RESPONSE_MODEL, model);
           agentSpan.setAttribute("openclaw.agent.success", success);
 
@@ -1782,13 +1754,11 @@ export function registerHooks(
             agentSpan.setAttribute(GEN_AI_PROVIDER_NAME, diagUsage.provider);
           }
 
-          // Cache tokens — dual-emit legacy + stable input_tokens forms.
+          // Cache tokens — stable `cache_*.input_tokens` only.
           if (cacheReadTokens > 0) {
-            agentSpan.setAttribute(GEN_AI_USAGE_CACHE_READ_TOKENS, cacheReadTokens);
             agentSpan.setAttribute(GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, cacheReadTokens);
           }
           if (cacheWriteTokens > 0) {
-            agentSpan.setAttribute(GEN_AI_USAGE_CACHE_WRITE_TOKENS, cacheWriteTokens);
             agentSpan.setAttribute(GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, cacheWriteTokens);
           }
 

--- a/src/semconv.ts
+++ b/src/semconv.ts
@@ -15,12 +15,6 @@
  */
 
 // ── GenAI stable attribute keys ─────────────────────────────────────
-/**
- * @deprecated Replaced by {@link GEN_AI_PROVIDER_NAME} in OTel GenAI
- * semantic conventions (2026-04). Dual-emitted alongside the new key in
- * schema `1.2.0`; planned removal target: schema `1.3.0` / plugin `0.5.0`.
- */
-export const GEN_AI_SYSTEM = "gen_ai.system";
 export const GEN_AI_OPERATION_NAME = "gen_ai.operation.name";
 export const GEN_AI_PROVIDER_NAME = "gen_ai.provider.name";
 export const GEN_AI_REQUEST_MODEL = "gen_ai.request.model";
@@ -37,30 +31,10 @@ export const GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id";
 export const GEN_AI_TOOL_TYPE = "gen_ai.tool.type";
 export const GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens";
 export const GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens";
-/**
- * @deprecated Consumers should compute `input + output` instead of relying
- * on a separately emitted total. Kept for backward compatibility during
- * schema `1.2.x`; planned removal target: schema `1.3.0` / plugin `0.5.0`.
- */
-export const GEN_AI_USAGE_TOTAL_TOKENS = "gen_ai.usage.total_tokens";
 /** Stable cache attributes (OTel GenAI semconv 2026-04). */
 export const GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens";
 export const GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS =
   "gen_ai.usage.cache_creation.input_tokens";
-/**
- * @deprecated Replaced by {@link GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS} in
- * OTel GenAI semantic conventions (2026-04). Dual-emitted alongside the
- * stable key in schema `1.2.0`; planned removal target: schema `1.3.0` /
- * plugin `0.5.0`.
- */
-export const GEN_AI_USAGE_CACHE_READ_TOKENS = "gen_ai.usage.cache_read_tokens";
-/**
- * @deprecated Replaced by {@link GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS}
- * in OTel GenAI semantic conventions (2026-04). Dual-emitted alongside the
- * stable key in schema `1.2.0`; planned removal target: schema `1.3.0` /
- * plugin `0.5.0`.
- */
-export const GEN_AI_USAGE_CACHE_WRITE_TOKENS = "gen_ai.usage.cache_write_tokens";
 /** Used on `gen_ai.client.token.usage` histogram to distinguish input / output. */
 export const GEN_AI_TOKEN_TYPE = "gen_ai.token.type";
 
@@ -84,20 +58,6 @@ export const spanNameExecuteTool = (toolName: string): string =>
 export const ERROR_TYPE = "error.type";
 
 // ── Code conventions ────────────────────────────────────────────────
-/**
- * @deprecated Replaced by {@link CODE_FUNCTION_NAME} (fully-qualified
- * `namespace.function`) in OTel general semantic conventions (2026-04).
- * Dual-emitted alongside the new key in schema `1.2.0`; planned removal
- * target: schema `1.3.0` / plugin `0.5.0`.
- */
-export const CODE_FUNCTION = "code.function";
-/**
- * @deprecated Folded into {@link CODE_FUNCTION_NAME} as the prefix segment
- * in OTel general semantic conventions (2026-04). Dual-emitted alongside
- * the new key in schema `1.2.0`; planned removal target: schema `1.3.0` /
- * plugin `0.5.0`.
- */
-export const CODE_NAMESPACE = "code.namespace";
 /** Stable: fully-qualified function identifier, e.g. `namespace.function`. */
 export const CODE_FUNCTION_NAME = "code.function.name";
 /** Stable: repo-relative source file path of the emit site. */
@@ -153,18 +113,20 @@ export const OC_CRON_AGENT_ID = "openclaw.cron.agent_id";
  * Schema version for plugin-domain attributes. Bump when emitted
  * attribute keys or values change in a way that consumers need to know.
  *
- * `1.2.0` — Dual-emit window for the OTel GenAI / code semconv 2026-04
- * migration: spans that previously emitted `gen_ai.system`,
- * `code.function` / `code.namespace`, or `gen_ai.usage.cache_*_tokens`
- * now also emit the stable replacements (`gen_ai.provider.name`,
- * `code.function.name` + `code.file.path`,
- * `gen_ai.usage.cache_read.input_tokens` /
- * `gen_ai.usage.cache_creation.input_tokens`). The legacy keys (and
- * `gen_ai.usage.total_tokens`) are kept for backward compatibility for
- * one minor release. Planned removal target: schema `1.3.0` / plugin
- * `0.5.0`.
+ * `1.3.0` — Closes the OTel GenAI / code semconv 2026-04 dual-emit
+ * window opened in `1.2.0`. The following legacy keys are no longer
+ * emitted (consumers must use the stable replacements shipped in
+ * `1.2.0`):
+ *
+ * | Removed (1.3.0)                       | Stable replacement                                                       |
+ * | ------------------------------------- | ------------------------------------------------------------------------ |
+ * | `gen_ai.system`                       | `gen_ai.provider.name`                                                   |
+ * | `code.function` + `code.namespace`    | `code.function.name` + `code.file.path`                                  |
+ * | `gen_ai.usage.cache_read_tokens`      | `gen_ai.usage.cache_read.input_tokens`                                   |
+ * | `gen_ai.usage.cache_write_tokens`     | `gen_ai.usage.cache_creation.input_tokens`                               |
+ * | `gen_ai.usage.total_tokens`           | none — consumers compute `input + output` (per `1.2.0` deprecation note) |
  */
-export const OPENCLAW_SCHEMA_VERSION = "1.2.0";
+export const OPENCLAW_SCHEMA_VERSION = "1.3.0";
 
 // ── Token type values ───────────────────────────────────────────────
 export const TOKEN_TYPE_INPUT = "input";

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -266,7 +266,9 @@ describe("plugin hook registration (ISI-730 migration)", () => {
     expect(turnSpan!.attrs["openclaw.session.key"]).toBe("session-123");
     expect(turnSpan!.attrs["gen_ai.agent.id"]).toBe("claude-4");
     expect(turnSpan!.attrs["gen_ai.conversation.id"]).toBe("session-123");
-    expect(turnSpan!.attrs["code.function"]).toBe("before_model_resolve");
+    expect(turnSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.before_model_resolve");
+    expect(turnSpan!.attrs["code.function"]).toBeUndefined();
+    expect(turnSpan!.attrs["code.namespace"]).toBeUndefined();
     // Model is NOT known at this point — must NOT be set.
     expect(turnSpan!.attrs["gen_ai.request.model"]).toBeUndefined();
     expect(turnSpan!.attrs["openclaw.agent.model"]).toBeUndefined();
@@ -613,13 +615,14 @@ describe("model_call_started / model_call_ended hooks (ISI-926)", () => {
     const chatSpan = spans.find((s) => s.spanName === "chat gpt-4o");
     expect(chatSpan).toBeDefined();
     expect(chatSpan!.attrs["gen_ai.operation.name"]).toBe("chat");
-    expect(chatSpan!.attrs["gen_ai.system"]).toBe("openai");
     expect(chatSpan!.attrs["gen_ai.provider.name"]).toBe("openai");
+    expect(chatSpan!.attrs["gen_ai.system"]).toBeUndefined();
     expect(chatSpan!.attrs["gen_ai.request.model"]).toBe("gpt-4o");
     expect(chatSpan!.attrs["gen_ai.request.stream"]).toBe(true);
     expect(chatSpan!.attrs["gen_ai.request.max_tokens"]).toBe(4096);
     expect(chatSpan!.attrs["gen_ai.conversation.id"]).toBe("s1");
-    expect(chatSpan!.attrs["code.function"]).toBe("model_call_started");
+    expect(chatSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.model_call_started");
+    expect(chatSpan!.attrs["code.function"]).toBeUndefined();
     expect(chatSpan!.ended).toBe(false);
 
     stopHooks();
@@ -670,7 +673,7 @@ describe("model_call_started / model_call_ended hooks (ISI-926)", () => {
     expect(chatSpan!.attrs["gen_ai.usage.output_tokens"]).toBe(80);
     expect(chatSpan!.attrs["gen_ai.usage.cache_read.input_tokens"]).toBe(100);
     expect(chatSpan!.attrs["gen_ai.usage.cache_creation.input_tokens"]).toBe(20);
-    expect(chatSpan!.attrs["gen_ai.usage.total_tokens"]).toBe(290);
+    expect(chatSpan!.attrs["gen_ai.usage.total_tokens"]).toBeUndefined();
     expect(chatSpan!.ended).toBe(true);
 
     stopHooks();
@@ -924,7 +927,8 @@ describe("before_tool_call / after_tool_call hooks (ISI-927)", () => {
     expect(toolSpan!.attrs["gen_ai.operation.name"]).toBe("execute_tool");
     expect(toolSpan!.attrs["gen_ai.conversation.id"]).toBe("s1");
     expect(toolSpan!.attrs["gen_ai.agent.id"]).toBe("a1");
-    expect(toolSpan!.attrs["code.function"]).toBe("before_tool_call");
+    expect(toolSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.before_tool_call");
+    expect(toolSpan!.attrs["code.function"]).toBeUndefined();
     expect(toolSpan!.attrs["openclaw.tool.input_preview"]).toBe('{"path":"/etc/hosts"}');
     expect(toolSpan!.ended).toBe(false);
 
@@ -1136,7 +1140,8 @@ describe("before_tool_call / after_tool_call hooks (ISI-927)", () => {
     const toolSpan = spans.find((s) => s.spanName === "execute_tool Grep");
     expect(toolSpan).toBeDefined();
     expect(toolSpan!.attrs["gen_ai.tool.name"]).toBe("Grep");
-    expect(toolSpan!.attrs["code.function"]).toBe("tool_result_persist");
+    expect(toolSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.tool_result_persist");
+    expect(toolSpan!.attrs["code.function"]).toBeUndefined();
     expect(toolSpan!.ended).toBe(true);
 
     stopHooks();
@@ -1232,7 +1237,8 @@ describe("session_start / session_end hooks (ISI-928)", () => {
     expect(sessionSpan!.attrs["openclaw.session.key"]).toBe("sess-1");
     expect(sessionSpan!.attrs["openclaw.session.channel"]).toBe("cli");
     expect(sessionSpan!.attrs["openclaw.session.user_id"]).toBe("user-42");
-    expect(sessionSpan!.attrs["code.function"]).toBe("session_start");
+    expect(sessionSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.session_start");
+    expect(sessionSpan!.attrs["code.function"]).toBeUndefined();
     expect(sessionSpan!.ended).toBe(false);
 
     expect(telemetry.gauges.activeSessions.add).toHaveBeenCalledWith(1, expect.any(Object));
@@ -1453,7 +1459,8 @@ describe("before_dispatch / reply_dispatch hooks (ISI-928)", () => {
     expect(dispatchSpan!.attrs["gen_ai.conversation.id"]).toBe("s1");
     expect(dispatchSpan!.attrs["gen_ai.request.model"]).toBe("gpt-4o");
     expect(dispatchSpan!.attrs["gen_ai.provider.name"]).toBe("openai");
-    expect(dispatchSpan!.attrs["code.function"]).toBe("before_dispatch");
+    expect(dispatchSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.before_dispatch");
+    expect(dispatchSpan!.attrs["code.function"]).toBeUndefined();
     expect(dispatchSpan!.ended).toBe(false);
 
     stopHooks();
@@ -1605,7 +1612,8 @@ describe("before_agent_finalize / before_reset hooks (ISI-928)", () => {
     expect(finalizeSpan!.attrs["gen_ai.conversation.id"]).toBe("s1");
     expect(finalizeSpan!.attrs["gen_ai.agent.id"]).toBe("a1");
     expect(finalizeSpan!.attrs["openclaw.agent.pending_messages"]).toBe(2);
-    expect(finalizeSpan!.attrs["code.function"]).toBe("before_agent_finalize");
+    expect(finalizeSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.before_agent_finalize");
+    expect(finalizeSpan!.attrs["code.function"]).toBeUndefined();
     expect(finalizeSpan!.ended).toBe(true);
 
     stopHooks();
@@ -1643,7 +1651,8 @@ describe("before_agent_finalize / before_reset hooks (ISI-928)", () => {
     expect(resetSpan!.attrs["gen_ai.conversation.id"]).toBe("s1");
     expect(resetSpan!.attrs["openclaw.session.key"]).toBe("s1");
     expect(resetSpan!.attrs["openclaw.session.reset_reason"]).toBe("user_requested");
-    expect(resetSpan!.attrs["code.function"]).toBe("before_reset");
+    expect(resetSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.before_reset");
+    expect(resetSpan!.attrs["code.function"]).toBeUndefined();
     expect(resetSpan!.ended).toBe(true);
 
     expect(telemetry.counters.sessionResets.add).toHaveBeenCalledWith(
@@ -1757,7 +1766,8 @@ describe("subagent_spawning / subagent_delivery_target / subagent_ended hooks (I
     expect(spawnSpan!.attrs["openclaw.subagent.child_agent_name"]).toBe("child-agent");
     expect(spawnSpan!.attrs["openclaw.subagent.spawn_reason"]).toBe("task_delegation");
     expect(spawnSpan!.attrs["gen_ai.operation.name"]).toBe("invoke_agent");
-    expect(spawnSpan!.attrs["code.function"]).toBe("subagent_spawning");
+    expect(spawnSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.subagent_spawning");
+    expect(spawnSpan!.attrs["code.function"]).toBeUndefined();
     expect(spawnSpan!.ended).toBe(false);
 
     expect(telemetry.counters.subagentSpawns.add).toHaveBeenCalledWith(
@@ -1794,7 +1804,8 @@ describe("subagent_spawning / subagent_delivery_target / subagent_ended hooks (I
     expect(deliverySpan!.attrs["openclaw.subagent.parent_session_key"]).toBe("parent-sess");
     expect(deliverySpan!.attrs["openclaw.subagent.child_session_key"]).toBe("child-sess");
     expect(deliverySpan!.attrs["openclaw.subagent.delivery_type"]).toBe("task_prompt");
-    expect(deliverySpan!.attrs["code.function"]).toBe("subagent_delivery_target");
+    expect(deliverySpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.subagent_delivery_target");
+    expect(deliverySpan!.attrs["code.function"]).toBeUndefined();
     expect(deliverySpan!.ended).toBe(true);
 
     stopHooks();
@@ -1982,7 +1993,8 @@ describe("cron_changed / cron_executed hooks (ISI-929)", () => {
     expect(cronSpan!.attrs["openclaw.cron.expression"]).toBe("*/5 * * * *");
     expect(cronSpan!.attrs["gen_ai.agent.id"]).toBe("agent-1");
     expect(cronSpan!.attrs["gen_ai.provider.name"]).toBe("openai");
-    expect(cronSpan!.attrs["code.function"]).toBe("cron_changed");
+    expect(cronSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.cron_changed");
+    expect(cronSpan!.attrs["code.function"]).toBeUndefined();
     expect(cronSpan!.ended).toBe(true);
 
     expect(telemetry.counters.cronChanges.add).toHaveBeenCalledWith(
@@ -2037,7 +2049,8 @@ describe("cron_changed / cron_executed hooks (ISI-929)", () => {
     expect(cronSpan!.attrs["openclaw.cron.agent_id"]).toBe("agent-2");
     expect(cronSpan!.attrs["gen_ai.agent.id"]).toBe("agent-2");
     expect(cronSpan!.attrs["gen_ai.provider.name"]).toBe("anthropic");
-    expect(cronSpan!.attrs["code.function"]).toBe("cron_executed");
+    expect(cronSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.cron_executed");
+    expect(cronSpan!.attrs["code.function"]).toBeUndefined();
     // ISI-993: `cron_executed` is not a valid OTel gen_ai.operation.name value.
     expect(cronSpan!.attrs["gen_ai.operation.name"]).toBeUndefined();
     expect(cronSpan!.ended).toBe(true);
@@ -2511,21 +2524,18 @@ describe("content capture policy gating (ISI-1000)", () => {
   });
 });
 
-// ── ISI-994: OTel semconv 2026-04 dual-emit window ──────────────────
+// ── ISI-1004: closure of the ISI-994 dual-emit window ───────────────
 //
-// Schema 1.2.0 dual-emits four groups of legacy attributes alongside
-// their stable replacements during a one-minor-release deprecation
-// window. The legacy keys MUST continue to be emitted exactly where they
-// used to be — these tests pin down both halves of the dual-emit so a
-// premature removal in 1.3.0 cannot quietly land without flipping the
-// expectations explicitly.
+// Schema 1.2.0 dual-emitted four groups of legacy attributes alongside
+// their stable replacements. Schema 1.3.0 closes that window: the legacy
+// keys MUST NOT be emitted any more. These tests pin the *removal* — the
+// inverse of the dual-emit tests they replaced — so a regression that
+// re-introduces a legacy key fails loudly.
 
-describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
+describe("ISI-1004: legacy semconv keys removed (schema 1.3.0)", () => {
   let stopHooks: (() => void) | undefined;
 
   afterEach(() => {
-    // Defensive cleanup: a thrown expect leaves stopHooks unrun, which
-    // leaks hook registrations into the next test. Always release here.
     try {
       stopHooks?.();
     } catch {
@@ -2534,7 +2544,7 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     stopHooks = undefined;
   });
 
-  it("llm_input dual-emits gen_ai.system + gen_ai.provider.name AND code.* legacy + stable", () => {
+  it("llm_input emits only stable gen_ai.provider.name + code.function.name (no legacy)", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
@@ -2542,27 +2552,27 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     const resolve = typedHooks.get("before_model_resolve")!;
     const llmInput = typedHooks.get("llm_input")!;
 
-    resolve({}, { agentId: "a1", sessionKey: "s-994a" });
+    resolve({}, { agentId: "a1", sessionKey: "s-1004a" });
     llmInput(
-      { sessionKey: "s-994a", agentId: "a1", model: "gpt-4o", provider: "openai" },
-      { sessionKey: "s-994a" },
+      { sessionKey: "s-1004a", agentId: "a1", model: "gpt-4o", provider: "openai" },
+      { sessionKey: "s-1004a" },
     );
 
     const llmCall = spans.find((s) => s.spanName === "openclaw.llm.call");
     expect(llmCall).toBeDefined();
 
-    // gen_ai provider dual-emit
-    expect(llmCall!.attrs["gen_ai.system"]).toBe("openai");
+    // Stable keys present
     expect(llmCall!.attrs["gen_ai.provider.name"]).toBe("openai");
-
-    // code.* dual-emit: legacy + stable forms must both land
-    expect(llmCall!.attrs["code.function"]).toBe("llm_input");
-    expect(llmCall!.attrs["code.namespace"]).toBe("openclaw.otel.hooks");
     expect(llmCall!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.llm_input");
     expect(llmCall!.attrs["code.file.path"]).toBe("src/hooks.ts");
+
+    // Legacy keys must not be emitted any more
+    expect(llmCall!.attrs["gen_ai.system"]).toBeUndefined();
+    expect(llmCall!.attrs["code.function"]).toBeUndefined();
+    expect(llmCall!.attrs["code.namespace"]).toBeUndefined();
   });
 
-  it("llm_output dual-emits cache_*_tokens (legacy) + cache_*.input_tokens (stable)", () => {
+  it("llm_output emits only stable cache_*.input_tokens (no legacy cache_*_tokens, no total_tokens)", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
@@ -2571,14 +2581,14 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     const llmInput = typedHooks.get("llm_input")!;
     const llmOutput = typedHooks.get("llm_output")!;
 
-    resolve({}, { agentId: "a1", sessionKey: "s-994b" });
+    resolve({}, { agentId: "a1", sessionKey: "s-1004b" });
     llmInput(
-      { sessionKey: "s-994b", agentId: "a1", model: "gpt-4o", provider: "openai" },
-      { sessionKey: "s-994b" },
+      { sessionKey: "s-1004b", agentId: "a1", model: "gpt-4o", provider: "openai" },
+      { sessionKey: "s-1004b" },
     );
     llmOutput(
       {
-        sessionKey: "s-994b",
+        sessionKey: "s-1004b",
         responseModel: "gpt-4o-2024-08-06",
         usage: {
           input: 100,
@@ -2587,21 +2597,23 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
           cacheWrite: 40,
         },
       },
-      { sessionKey: "s-994b" },
+      { sessionKey: "s-1004b" },
     );
 
     const llmCall = spans.find((s) => s.spanName === "openclaw.llm.call");
     expect(llmCall).toBeDefined();
 
-    // Legacy keys still emitted
-    expect(llmCall!.attrs["gen_ai.usage.cache_read_tokens"]).toBe(800);
-    expect(llmCall!.attrs["gen_ai.usage.cache_write_tokens"]).toBe(40);
-    // Stable replacements also emitted
+    // Stable replacements present
     expect(llmCall!.attrs["gen_ai.usage.cache_read.input_tokens"]).toBe(800);
     expect(llmCall!.attrs["gen_ai.usage.cache_creation.input_tokens"]).toBe(40);
+
+    // Legacy keys removed
+    expect(llmCall!.attrs["gen_ai.usage.cache_read_tokens"]).toBeUndefined();
+    expect(llmCall!.attrs["gen_ai.usage.cache_write_tokens"]).toBeUndefined();
+    expect(llmCall!.attrs["gen_ai.usage.total_tokens"]).toBeUndefined();
   });
 
-  it("non-LLM hook spans (session_start) also dual-emit code.* keys", () => {
+  it("non-LLM hook spans (session_start) emit only stable code.function.name (no legacy)", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
@@ -2609,25 +2621,25 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     const sessionStart = typedHooks.get("session_start")!;
     sessionStart(
       {
-        sessionKey: "s-994c",
+        sessionKey: "s-1004c",
         agentId: "a1",
         channel: "cli",
         userId: "u1",
       },
-      { sessionKey: "s-994c" },
+      { sessionKey: "s-1004c" },
     );
 
     const sessionSpan = spans.find((s) => s.spanName === "openclaw.session");
     expect(sessionSpan).toBeDefined();
-    expect(sessionSpan!.attrs["code.function"]).toBe("session_start");
-    expect(sessionSpan!.attrs["code.namespace"]).toBe("openclaw.otel.hooks");
     expect(sessionSpan!.attrs["code.function.name"]).toBe(
       "openclaw.otel.hooks.session_start",
     );
     expect(sessionSpan!.attrs["code.file.path"]).toBe("src/hooks.ts");
+    expect(sessionSpan!.attrs["code.function"]).toBeUndefined();
+    expect(sessionSpan!.attrs["code.namespace"]).toBeUndefined();
   });
 
-  it("dispatch.prepare span dual-emits code.* legacy + stable forms (incl. code.namespace)", () => {
+  it("dispatch.prepare span emits only stable code.function.name (no legacy code.function / code.namespace)", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
@@ -2635,23 +2647,23 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     const resolve = typedHooks.get("before_model_resolve")!;
     const beforeDispatch = typedHooks.get("before_dispatch")!;
 
-    resolve({}, { agentId: "a1", sessionKey: "s-994d" });
+    resolve({}, { agentId: "a1", sessionKey: "s-1004d" });
     beforeDispatch(
-      { sessionKey: "s-994d", agentId: "a1", model: "gpt-4o", provider: "openai" },
-      { sessionKey: "s-994d" },
+      { sessionKey: "s-1004d", agentId: "a1", model: "gpt-4o", provider: "openai" },
+      { sessionKey: "s-1004d" },
     );
 
     const dispatchSpan = spans.find((s) => s.spanName === "openclaw.dispatch.prepare");
     expect(dispatchSpan).toBeDefined();
-    expect(dispatchSpan!.attrs["code.function"]).toBe("before_dispatch");
-    expect(dispatchSpan!.attrs["code.namespace"]).toBe("openclaw.otel.hooks");
     expect(dispatchSpan!.attrs["code.function.name"]).toBe(
       "openclaw.otel.hooks.before_dispatch",
     );
     expect(dispatchSpan!.attrs["code.file.path"]).toBe("src/hooks.ts");
+    expect(dispatchSpan!.attrs["code.function"]).toBeUndefined();
+    expect(dispatchSpan!.attrs["code.namespace"]).toBeUndefined();
   });
 
-  it("model_call_started span dual-emits gen_ai.system + gen_ai.provider.name", () => {
+  it("model_call_started span emits only stable gen_ai.provider.name (no legacy gen_ai.system)", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
@@ -2659,21 +2671,19 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     const resolve = typedHooks.get("before_model_resolve")!;
     const modelCallStarted = typedHooks.get("model_call_started")!;
 
-    resolve({}, { agentId: "a1", sessionKey: "s-994e" });
+    resolve({}, { agentId: "a1", sessionKey: "s-1004e" });
     modelCallStarted(
-      { sessionKey: "s-994e", agentId: "a1", model: "gpt-4o", provider: "openai" },
-      { sessionKey: "s-994e" },
+      { sessionKey: "s-1004e", agentId: "a1", model: "gpt-4o", provider: "openai" },
+      { sessionKey: "s-1004e" },
     );
 
     const chatSpan = spans.find((s) => s.spanName === "chat gpt-4o");
     expect(chatSpan).toBeDefined();
-    // Both halves of the dual-emit must land — without this assertion,
-    // either could silently regress without flipping the legacy key.
-    expect(chatSpan!.attrs["gen_ai.system"]).toBe("openai");
     expect(chatSpan!.attrs["gen_ai.provider.name"]).toBe("openai");
+    expect(chatSpan!.attrs["gen_ai.system"]).toBeUndefined();
   });
 
-  it("agent_end safety-net dual-emits cache + provider attrs on the leftover LLM span", async () => {
+  it("agent_end safety-net emits only stable cache_*.input_tokens (no legacy cache_*_tokens)", async () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
@@ -2682,21 +2692,19 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
     const llmInput = typedHooks.get("llm_input")!;
     const agentEnd = typedHooks.get("agent_end")!;
 
-    resolve({}, { agentId: "a1", sessionKey: "s-994f" });
+    resolve({}, { agentId: "a1", sessionKey: "s-1004f" });
     // Open an LLM span via llm_input; do NOT close it via llm_output so the
     // agent_end safety net is exercised.
     llmInput(
-      { sessionKey: "s-994f", agentId: "a1", model: "claude-3.5", provider: "anthropic" },
-      { sessionKey: "s-994f" },
+      { sessionKey: "s-1004f", agentId: "a1", model: "claude-3.5", provider: "anthropic" },
+      { sessionKey: "s-1004f" },
     );
 
     await agentEnd(
       {
-        sessionKey: "s-994f",
+        sessionKey: "s-1004f",
         agentId: "a1",
         success: true,
-        // agent_end derives token counts from the assistant messages array
-        // (see fallback branch — no diagnostic events in this test).
         messages: [
           {
             role: "assistant",
@@ -2710,29 +2718,30 @@ describe("ISI-994: GenAI / code semconv dual-emit (schema 1.2.x)", () => {
           },
         ],
       },
-      { sessionKey: "s-994f" },
+      { sessionKey: "s-1004f" },
     );
 
     const llmCall = spans.find((s) => s.spanName === "openclaw.llm.call");
     expect(llmCall).toBeDefined();
-    // Both legacy + stable cache halves must be present on the safety-net
-    // close path so a 1.3.0 cleanup cannot silently drop one direction.
-    expect(llmCall!.attrs["gen_ai.usage.cache_read_tokens"]).toBe(1200);
+    // Only stable cache halves emitted; legacy keys gone.
     expect(llmCall!.attrs["gen_ai.usage.cache_read.input_tokens"]).toBe(1200);
-    expect(llmCall!.attrs["gen_ai.usage.cache_write_tokens"]).toBe(60);
     expect(llmCall!.attrs["gen_ai.usage.cache_creation.input_tokens"]).toBe(60);
+    expect(llmCall!.attrs["gen_ai.usage.cache_read_tokens"]).toBeUndefined();
+    expect(llmCall!.attrs["gen_ai.usage.cache_write_tokens"]).toBeUndefined();
+
+    // The agent turn span itself must also stop emitting total_tokens.
+    const agentTurn = spans.find((s) => s.spanName === "openclaw.agent.turn");
+    expect(agentTurn).toBeDefined();
+    expect(agentTurn!.attrs["gen_ai.usage.total_tokens"]).toBeUndefined();
   });
 });
 
-// ── ISI-994: diagnostics module dual-emit ────────────────────────────
+// ── ISI-1004: diagnostics module legacy removal ─────────────────────
 //
-// Pins the dual-emit invariants for `enrichSpanWithUsage` directly. This
-// is the path that fires when `model.usage` diagnostic events arrive
-// after the agent_end span has already been opened — the cache + provider
-// dual-emit lives here and is otherwise not exercised by the hooks tests.
+// Mirrors the hook-level removal tests above for `enrichSpanWithUsage`.
 
-describe("ISI-994: diagnostics.enrichSpanWithUsage dual-emit (schema 1.2.x)", () => {
-  it("dual-emits cache_*_tokens (legacy) + cache_*.input_tokens (stable)", () => {
+describe("ISI-1004: diagnostics.enrichSpanWithUsage legacy removal (schema 1.3.0)", () => {
+  it("emits only stable cache_*.input_tokens (no legacy cache_*_tokens)", () => {
     const span = createSpanSpy("openclaw.agent.turn");
     enrichSpanWithUsage(span, {
       usage: {
@@ -2745,15 +2754,15 @@ describe("ISI-994: diagnostics.enrichSpanWithUsage dual-emit (schema 1.2.x)", ()
     });
 
     const spy = span as unknown as SpanSpy;
-    // Legacy cache keys still emitted
-    expect(spy.attrs["gen_ai.usage.cache_read_tokens"]).toBe(800);
-    expect(spy.attrs["gen_ai.usage.cache_write_tokens"]).toBe(40);
-    // Stable cache replacements emitted alongside
+    // Stable replacements present
     expect(spy.attrs["gen_ai.usage.cache_read.input_tokens"]).toBe(800);
     expect(spy.attrs["gen_ai.usage.cache_creation.input_tokens"]).toBe(40);
+    // Legacy keys removed
+    expect(spy.attrs["gen_ai.usage.cache_read_tokens"]).toBeUndefined();
+    expect(spy.attrs["gen_ai.usage.cache_write_tokens"]).toBeUndefined();
   });
 
-  it("dual-emits gen_ai.system (legacy) + gen_ai.provider.name (stable)", () => {
+  it("emits only stable gen_ai.provider.name (no legacy gen_ai.system)", () => {
     const span = createSpanSpy("openclaw.agent.turn");
     enrichSpanWithUsage(span, {
       usage: {},
@@ -2762,13 +2771,12 @@ describe("ISI-994: diagnostics.enrichSpanWithUsage dual-emit (schema 1.2.x)", ()
     });
 
     const spy = span as unknown as SpanSpy;
-    expect(spy.attrs["gen_ai.system"]).toBe("anthropic");
     expect(spy.attrs["gen_ai.provider.name"]).toBe("anthropic");
-    // gen_ai.response.model is emitted via the constant, not a raw string.
+    expect(spy.attrs["gen_ai.system"]).toBeUndefined();
     expect(spy.attrs["gen_ai.response.model"]).toBe("claude-3.5-sonnet");
   });
 
-  it("still emits the deprecated gen_ai.usage.total_tokens during the dual-emit window", () => {
+  it("no longer emits gen_ai.usage.total_tokens", () => {
     const span = createSpanSpy("openclaw.agent.turn");
     enrichSpanWithUsage(span, {
       usage: { input: 100, output: 50, total: 150 },
@@ -2777,7 +2785,7 @@ describe("ISI-994: diagnostics.enrichSpanWithUsage dual-emit (schema 1.2.x)", ()
     const spy = span as unknown as SpanSpy;
     expect(spy.attrs["gen_ai.usage.input_tokens"]).toBe(100);
     expect(spy.attrs["gen_ai.usage.output_tokens"]).toBe(50);
-    expect(spy.attrs["gen_ai.usage.total_tokens"]).toBe(150);
+    expect(spy.attrs["gen_ai.usage.total_tokens"]).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes the OTel GenAI / code semconv 2026-04 **dual-emit window** opened
in schema `1.2.0` (ISI-994). At schema `1.3.0` / plugin `0.5.0` the
legacy attribute keys are no longer emitted; consumers must read the
stable replacements that already shipped in `1.2.0`.

| Removed (1.3.0)                       | Stable replacement (already in 1.2.0)                                    |
| ------------------------------------- | ------------------------------------------------------------------------ |
| `gen_ai.system`                       | `gen_ai.provider.name`                                                   |
| `code.function` + `code.namespace`    | `code.function.name` + `code.file.path`                                  |
| `gen_ai.usage.cache_read_tokens`      | `gen_ai.usage.cache_read.input_tokens`                                   |
| `gen_ai.usage.cache_write_tokens`     | `gen_ai.usage.cache_creation.input_tokens`                               |
| `gen_ai.usage.total_tokens`           | *(none — compute `input + output`)*                                      |

Issue: [ISI-1004](https://app.paperclip.ing/ISI/issues/ISI-1004)
(child of [ISI-994](https://app.paperclip.ing/ISI/issues/ISI-994)).

## Changes

### `src/semconv.ts`
- Dropped exports: `GEN_AI_SYSTEM`, `CODE_FUNCTION`, `CODE_NAMESPACE`,
  `GEN_AI_USAGE_CACHE_READ_TOKENS`, `GEN_AI_USAGE_CACHE_WRITE_TOKENS`,
  `GEN_AI_USAGE_TOTAL_TOKENS`.
- Bumped `OPENCLAW_SCHEMA_VERSION` → `"1.3.0"` and rewrote its JSDoc as a
  removal table referencing each stable replacement.

### `src/hooks.ts`
- Dropped legacy `gen_ai.system` emit from the `llm_input` and
  `model_call_started` span attributes.
- Dropped legacy `gen_ai.usage.cache_*_tokens` and
  `gen_ai.usage.total_tokens` emits from `llm_output`, `model_call_ended`,
  and both `agent_end` safety nets. Stable `cache_*.input_tokens` only.
- `codeAttrs(funcName)` helper now returns just `code.function.name` +
  `code.file.path` (no more `code.function` / `code.namespace`).
- Removed the legacy `totalTokens` derived locals that became dead after
  dropping the span emits (metric-side `tokensTotal` counter still uses
  its own derivation in the `!diagUsage` branch).

### `src/diagnostics.ts`
- `model.usage` metric attribute set no longer carries `gen_ai.system`.
- `enrichSpanWithUsage` no longer emits `gen_ai.system`,
  `gen_ai.usage.cache_*_tokens`, or `gen_ai.usage.total_tokens`.

### `tests/hooks.test.ts`
- The ISI-994 `dual-emit` describe block is replaced by an ISI-1004
  `legacy removal` block whose assertions are the inverse — every legacy
  key is pinned to `toBeUndefined()` and only the stable forms are
  expected. The diagnostics dual-emit block gets the same treatment.
- Pre-existing assertions elsewhere in the file (`code.function`,
  `gen_ai.system`, `gen_ai.usage.total_tokens`) flipped to read the stable
  key and assert the legacy form is undefined.

### Docs
- `CHANGELOG.md`: new `Unreleased ### Removed` block with the migration
  table and a consumer-action note.
- `docs/architecture.md`: deprecated-attributes table rewritten as a
  removal table; the stand-alone `gen_ai.system` row in the main
  attribute table is gone.
- `docs/migration-v2-to-v3.md`: the 1.2.0 dual-emit callout flipped to a
  1.3.0 removal callout pointing to the new architecture anchor.
- `docs/telemetry/{traces,tokens}.md`: stale legacy keys swapped for
  stable forms; total-tokens removal called out with the
  `input + output` formula. DQL example updated to compute the total
  client-side.

### `package.json`
- `version: "0.3.1"` → `"0.5.0"` per the ISI-1004 release checklist.

## Test plan

- [x] `npm test` — 8 files / 232 passed (including the new
  `ISI-1004: legacy semconv keys removed` and
  `ISI-1004: diagnostics.enrichSpanWithUsage legacy removal` blocks).
- [x] `npx tsc --noEmit` — clean.
- [x] `grep -nR` confirms no remaining references to `GEN_AI_SYSTEM`,
  `CODE_FUNCTION`, `CODE_NAMESPACE`, `GEN_AI_USAGE_CACHE_READ_TOKENS`,
  `GEN_AI_USAGE_CACHE_WRITE_TOKENS`, or `GEN_AI_USAGE_TOTAL_TOKENS`
  anywhere under `src/`.
- [ ] **Consumer pre-merge gate (per ISI-1004 checklist):** validate via
  the dev environment that Dynatrace dashboards have been migrated to
  the stable keys before merging. `1.2.0` shipped in PR #34; consumers
  need at least one minor release on their fleet before this PR lands.

## Notes

- This is the cleanup-only PR — the dual-emit changes themselves were in
  [ISI-994 / PR #34](https://github.com/henrikrexed/openclaw-observability-plugin/pull/34).
- Hygiene fixes (Story 3) stay scoped to
  [ISI-995](https://app.paperclip.ing/ISI/issues/ISI-995); not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
