### PR TITLE
docs: attribute openclaw.tokens / openclaw.cost.usd to diagnostics-otel (ISI-1006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ openclaw gateway restart
 
 ### What It Captures
 
-**Metrics:**
+> All metrics in this section are emitted by the Gateway's built-in `diagnostics-otel` plugin — **not** by this repo's custom plugin. The custom plugin emits `openclaw.llm.*` and `gen_ai.*` instead (see Approach 2 below).
+
+**Metrics (from `diagnostics-otel`):**
 - `openclaw.tokens` — Token usage by type (input/output/cache)
 - `openclaw.cost.usd` — Estimated model cost
 - `openclaw.run.duration_ms` — Agent run duration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,9 @@ Gateway Core                    diagnostics-otel Plugin
 
 ### OTel Signals Created
 
-**Metrics:**
+> Everything in this subsection is produced by the Gateway-built-in `diagnostics-otel` plugin. The custom plugin in this repo (Approach 2 below) emits a different metric set (`openclaw.llm.*` + `gen_ai.*`).
+
+**Metrics (emitted by `diagnostics-otel`):**
 ```
 openclaw.tokens{type="input|output|cache_read|cache_write"}
 openclaw.cost.usd
@@ -106,14 +108,14 @@ openclaw.session.stuck
 openclaw.session.stuck_age_ms
 ```
 
-**Traces:**
+**Traces (emitted by `diagnostics-otel`):**
 - `openclaw.model.usage` — Per LLM call span
 - `openclaw.webhook.processed` — Per webhook span
 - `openclaw.webhook.error` — Error span (with status=ERROR)
 - `openclaw.message.processed` — Per message span
 - `openclaw.session.stuck` — Stuck detection span
 
-**Logs:**
+**Logs (emitted by `diagnostics-otel`):**
 - All Gateway logs as OTel LogRecords
 - Includes severity, subsystem, code location
 
@@ -292,6 +294,24 @@ openclaw.request (root)
             gen_ai.tool.name: "Write"
             openclaw.tool.result_chars: 0
 ```
+
+### OTel Signals Created
+
+**Metrics (emitted by this plugin):**
+```
+openclaw.llm.tokens.total        # counter, by gen_ai.response.model
+openclaw.llm.tokens.prompt       # counter
+openclaw.llm.tokens.completion   # counter
+openclaw.llm.cost.usd            # counter, by gen_ai.response.model
+openclaw.tool.calls              # counter
+openclaw.session.resets          # counter
+```
+
+The OTel-stable `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` are recorded as **span attributes** on the LLM/agent-turn spans (see the trace structure above) — not as separate metric instruments.
+
+**Traces (emitted by this plugin):** see the trace tree above (`openclaw.request` → `openclaw.session` → `openclaw.agent.turn` → child spans).
+
+**Note:** The legacy `openclaw.tokens` / `openclaw.cost.usd` counters are emitted only by the Gateway's built-in `diagnostics-otel` plugin (Approach 1). They are **not** emitted by this plugin.
 
 ---
 

--- a/docs/backends/dynatrace.md
+++ b/docs/backends/dynatrace.md
@@ -89,25 +89,36 @@ openclaw gateway restart
 1. Go to **Explore** → **Metrics**
 2. Search for `openclaw.`
 3. Available metrics:
-   - `openclaw.tokens` — Token usage
-   - `openclaw.cost.usd` — Cost tracking
+
+**From this plugin (`openclaw-observability`):**
+   - `openclaw.llm.tokens.total` / `openclaw.llm.tokens.prompt` / `openclaw.llm.tokens.completion` — Token usage by `gen_ai.response.model`
+   - `openclaw.llm.cost.usd` — Estimated model cost by `gen_ai.response.model`
+   - `openclaw.tool.calls` — Tool call counter
+   - `openclaw.session.resets` — Session reset counter
+
+**From the built-in `diagnostics-otel` plugin (only if you also enabled it in `openclaw.json`):**
+   - `openclaw.tokens` — Token usage (emitted by `diagnostics-otel`, not by this plugin)
+   - `openclaw.cost.usd` — Cost tracking (emitted by `diagnostics-otel`, not by this plugin)
    - `openclaw.run.duration_ms` — Agent run times
    - `openclaw.message.*` — Message processing
    - `openclaw.queue.*` — Queue metrics
 
 ### Create Dashboard
 
-Create a dashboard with:
+Create a dashboard with (queries below assume this plugin's metrics):
 
 ```sql
 -- Token usage by model
-timeseries sum(openclaw.tokens), by:{openclaw.model, openclaw.token}
+timeseries sum(openclaw.llm.tokens.total), by:{gen_ai.response.model}
 
 -- Cost over time
-timeseries sum(openclaw.cost.usd), by:{openclaw.model}
+timeseries sum(openclaw.llm.cost.usd), by:{gen_ai.response.model}
 
--- Agent run duration
-timeseries avg(openclaw.run.duration_ms), by:{openclaw.model}
+-- Agent turn duration (span attribute, query via spans)
+fetch spans
+| filter span.name == "openclaw.agent.turn"
+| summarize avg_duration = avg(openclaw.agent.duration_ms),
+    by:{gen_ai.response.model}
 ```
 
 ### View Logs
@@ -118,20 +129,22 @@ timeseries avg(openclaw.run.duration_ms), by:{openclaw.model}
 
 ## Example DQL Queries
 
+> The queries below target spans/metrics emitted by **this** plugin. If you only have the built-in `diagnostics-otel` plugin enabled, you'll need to swap `openclaw.llm.*` for `openclaw.tokens` / `openclaw.cost.usd` and adjust the group-by attribute to `openclaw.model`.
+
 ### Token Usage by Model
 ```sql
-fetch spans
-| filter dt.entity.service == "openclaw-gateway"
-| summarize tokens = sum(openclaw.tokens.total), by:{openclaw.model}
-| sort tokens desc
+timeseries tokens = sum(openclaw.llm.tokens.total),
+  by:{gen_ai.response.model}
+| sort arrayLast(tokens) desc
 ```
 
-### Average Run Duration
+### Average Agent Turn Duration
 ```sql
 fetch spans
 | filter dt.entity.service == "openclaw-gateway"
-| filter matchesPhrase(span.name, "model")
-| summarize avg_duration = avg(openclaw.run.duration_ms)
+| filter span.name == "openclaw.agent.turn"
+| summarize avg_duration = avg(openclaw.agent.duration_ms),
+    by:{gen_ai.response.model}
 ```
 
 ### Error Rate

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,9 +41,11 @@ openclaw gateway restart
 
 Send a message to your agent and check your backend for:
 
-- **Metrics:** `openclaw.tokens`, `openclaw.cost.usd`, `openclaw.run.duration_ms`
+- **Metrics (emitted by `diagnostics-otel`):** `openclaw.tokens`, `openclaw.cost.usd`, `openclaw.run.duration_ms`
 - **Traces:** `openclaw.model.usage`, `openclaw.message.processed`
 - **Logs:** Gateway logs with severity and code location
+
+> If you also installed Option 2 (this repo's custom plugin), the metrics from the custom plugin are different: `openclaw.llm.tokens.{total,prompt,completion}`, `openclaw.llm.cost.usd`, and the OTel stable `gen_ai.*` set.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,20 +65,20 @@ See [Getting Started](getting-started.md) for detailed instructions.
 
 ## What Gets Captured
 
-### Official Plugin
+### Official Plugin (`diagnostics-otel`, built into the Gateway)
 
 | Signal | Data |
 |--------|------|
-| **Metrics** | `openclaw.tokens`, `openclaw.cost.usd`, `openclaw.run.duration_ms`, `openclaw.webhook.*`, `openclaw.message.*`, `openclaw.queue.*`, `openclaw.session.*` |
+| **Metrics** | `openclaw.tokens`, `openclaw.cost.usd`, `openclaw.run.duration_ms`, `openclaw.webhook.*`, `openclaw.message.*`, `openclaw.queue.*`, `openclaw.session.*` (all emitted by `diagnostics-otel`, not by this plugin) |
 | **Traces** | Model usage, webhook processing, message processing, stuck sessions |
 | **Logs** | All Gateway logs with severity, subsystem, code location |
 
-### Custom Plugin (Additional)
+### Custom Plugin (This Repo)
 
 | Signal | Data |
 |--------|------|
 | **Traces** | `openclaw.request` → `openclaw.agent.turn` → `tool.*` (connected hierarchy) |
-| **Metrics** | `openclaw.llm.tokens.*`, `openclaw.tool.calls`, `openclaw.session.resets` |
+| **Metrics** | `openclaw.llm.tokens.{total,prompt,completion}`, `openclaw.llm.cost.usd`, `openclaw.tool.calls`, `openclaw.session.resets`, plus the OTel stable `gen_ai.*` set |
 
 ## Trace Structure Comparison
 


### PR DESCRIPTION
## Summary

Fixes [ISI-1006](https://app.paperclip.ing/ISI/issues/ISI-1006). The plugin docs previously listed `openclaw.tokens` and `openclaw.cost.usd` as metrics emitted by this plugin, but those come from the Gateway's built-in `diagnostics-otel` plugin. This plugin actually emits `openclaw.llm.tokens.{total,prompt,completion}`, `openclaw.llm.cost.usd`, and the OTel stable `gen_ai.*` set.

## Changes

- **README.md** / **docs/index.md** / **docs/getting-started.md** — keep the metric references in the Approach 1 / Option 1 sections (which describe the built-in plugin) but add explicit "(emitted by `diagnostics-otel`)" labels so the boundary is unambiguous.
- **docs/architecture.md** — explicit attribution on the Approach 1 metrics block, plus a new "OTel Signals Created" subsection under Approach 2 listing what this plugin actually emits, with a note that `openclaw.tokens` / `openclaw.cost.usd` are **not** from this plugin.
- **docs/backends/dynatrace.md** — split the "View Metrics" list into a this-plugin block and a diagnostics-otel block; fix DQL queries that targeted `openclaw.tokens.total` / `openclaw.run.duration_ms` / `openclaw.cost.usd` (now use `openclaw.llm.tokens.total`, `openclaw.llm.cost.usd`, and the `openclaw.agent.turn` span attribute `openclaw.agent.duration_ms`); add a fallback note for diagnostics-otel-only setups.

## Test plan

- [x] `grep -rn 'openclaw\.tokens\|openclaw\.cost\.usd' README.md docs/` — every remaining reference is explicitly attributed to `diagnostics-otel`.
- [ ] Reviewer eyeball-check the Dynatrace DQL examples render and group-by clauses match the v3 span attribute names already documented.
- [x] Doc-only change — no source/runtime/test impact.