### PR TITLE
feat(ISI-1017): add queue and session state metrics

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,84 @@
+# Implementation Plan: ISI-1017 through ISI-1020
+## Combined PR for Plugin Gap Closure
+
+### P2 — Queue & Session State Metrics (ISI-1017)
+**Files to modify:**
+- `src/diagnostics.ts`: Add queue and session event handlers
+- `src/telemetry.ts`: Add new histograms/counters
+- `src/semconv.ts`: Add new metric attribute keys
+
+**Events to handle:**
+- `queue.lane.enqueue` → counter `openclaw.queue.lane.enqueue`
+- `queue.lane.dequeue` → counter `openclaw.queue.lane.dequeue`
+- `queue.depth` → histogram `openclaw.queue.depth`
+- `queue.wait_ms` → histogram `openclaw.queue.wait_ms`
+- `session.stuck` → span + counter
+- `session.long_running` → span + counter
+- `session.stalled` → span + counter
+
+### P3 — Context Layer & Skill Usage (ISI-1018)
+**Files to modify:**
+- `src/hooks.ts`: Add `before_prompt_build` enrichment
+- `src/semconv.ts`: Add skill/context attribute keys
+
+**Features:**
+- `openclaw.context.build` span
+- Skill loading tracking
+- Token breakdown: system/user/tool_result/skill
+
+### P4 — Subagent Deep Tracing (ISI-1019)
+**Files to modify:**
+- `src/hooks.ts`: Enhance subagent spans (already has W3C fix)
+
+**Features:**
+- Child run traces with delivery details
+- Subagent model usage aggregation
+- Context fork detection
+
+### P5 — Webhook Observability (ISI-1020)
+**Files to modify:**
+- `src/diagnostics.ts`: Add webhook event handlers
+- `src/telemetry.ts`: Add webhook metrics
+
+**Events to handle:**
+- `webhook.received` → span + counter
+- `webhook.processed` → span
+- `webhook.error` → span + counter
+- `webhook.duration_ms` → histogram
+
+## Metrics to Add
+
+```typescript
+// Queue metrics
+openclaw.queue.lane.enqueue: Counter
+openclaw.queue.lane.dequeue: Counter
+openclaw.queue.depth: Histogram
+openclaw.queue.wait_ms: Histogram
+
+// Session metrics
+openclaw.session.stuck: Counter
+openclaw.session.long_running: Counter
+openclaw.session.stalled: Counter
+openclaw.session.stuck_age_ms: Histogram
+
+// Webhook metrics
+openclaw.webhook.received: Counter
+openclaw.webhook.processed: Counter
+openclaw.webhook.error: Counter
+openclaw.webhook.duration_ms: Histogram
+openclaw.webhook.payload_size_bytes: Histogram
+```
+
+## Spans to Add
+
+```
+openclaw.queue.lane.enqueue
+openclaw.queue.lane.dequeue
+openclaw.session.stuck
+openclaw.session.long_running
+openclaw.session.stalled
+openclaw.context.build
+openclaw.webhook.received
+openclaw.webhook.processed
+openclaw.webhook.error
+```

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -86,6 +86,54 @@ export async function registerDiagnosticsListener(
   const { counters, histograms } = telemetry;
 
   const unsubscribe = onDiagnosticEvent((evt: any) => {
+    // ISI-1017: Queue events
+    if (evt.type === "queue.lane.enqueue") {
+      const { lane, depth, waitMs } = evt;
+      const attrs: Record<string, string | number> = {};
+      if (lane) attrs["openclaw.queue.lane"] = lane;
+      counters.queueLaneEnqueue.add(1, attrs);
+      if (typeof depth === "number") histograms.queueDepth.record(depth, attrs);
+      if (typeof waitMs === "number") histograms.queueWaitMs.record(waitMs, attrs);
+      logger.debug?.(`[otel] queue.lane.enqueue: lane=${lane}, depth=${depth}, waitMs=${waitMs}`);
+      return;
+    }
+
+    if (evt.type === "queue.lane.dequeue") {
+      const { lane, depth } = evt;
+      const attrs: Record<string, string | number> = {};
+      if (lane) attrs["openclaw.queue.lane"] = lane;
+      counters.queueLaneDequeue.add(1, attrs);
+      if (typeof depth === "number") histograms.queueDepth.record(depth, attrs);
+      logger.debug?.(`[otel] queue.lane.dequeue: lane=${lane}, depth=${depth}`);
+      return;
+    }
+
+    // ISI-1017: Session events
+    if (evt.type === "session.stuck") {
+      const { sessionKey, ageMs } = evt;
+      const attrs = { "openclaw.session.key": sessionKey || "unknown" };
+      counters.sessionStuck.add(1, attrs);
+      if (typeof ageMs === "number") histograms.sessionStuckAgeMs.record(ageMs, attrs);
+      logger.debug?.(`[otel] session.stuck: session=${sessionKey}, ageMs=${ageMs}`);
+      return;
+    }
+
+    if (evt.type === "session.long_running") {
+      const { sessionKey, ageMs } = evt;
+      const attrs = { "openclaw.session.key": sessionKey || "unknown" };
+      counters.sessionLongRunning.add(1, attrs);
+      logger.debug?.(`[otel] session.long_running: session=${sessionKey}, ageMs=${ageMs}`);
+      return;
+    }
+
+    if (evt.type === "session.stalled") {
+      const { sessionKey, ageMs } = evt;
+      const attrs = { "openclaw.session.key": sessionKey || "unknown" };
+      counters.sessionStalled.add(1, attrs);
+      logger.debug?.(`[otel] session.stalled: session=${sessionKey}, ageMs=${ageMs}`);
+      return;
+    }
+
     if (evt.type !== "model.usage") return;
 
     const sessionKey = evt.sessionKey || "unknown";

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -171,6 +171,20 @@ export interface OtelCounters {
   subagentSpawns: Counter;
   /** Sub-agent completion events */
   subagentEnded: Counter;
+  /** Queue lane enqueue events */
+  queueLaneEnqueue: Counter;
+  /** Queue lane dequeue events */
+  queueLaneDequeue: Counter;
+  /** Session stuck events */
+  sessionStuck: Counter;
+  /** Session long-running events */
+  sessionLongRunning: Counter;
+  /** Session stalled events */
+  sessionStalled: Counter;
+  /** Liveness warning events */
+  livenessWarnings: Counter;
+  /** Diagnostic heartbeat events */
+  diagnosticHeartbeats: Counter;
 }
 
 export interface OtelHistograms {
@@ -190,11 +204,31 @@ export interface OtelHistograms {
   cronDuration: Histogram;
   /** Sub-agent duration in ms */
   subagentDuration: Histogram;
+  /** Queue depth */
+  queueDepth: Histogram;
+  /** Queue wait time in ms */
+  queueWaitMs: Histogram;
+  /** Session stuck age in ms */
+  sessionStuckAgeMs: Histogram;
+  /** Gateway event loop delay p99 in ms */
+  gatewayEventLoopDelayP99: Histogram;
+  /** Gateway event loop delay max in ms */
+  gatewayEventLoopDelayMax: Histogram;
+  /** Gateway event loop utilization */
+  gatewayEventLoopUtilization: Histogram;
+  /** Gateway CPU core ratio */
+  gatewayCpuCoreRatio: Histogram;
+  /** Gateway work queued */
+  gatewayWorkQueued: Histogram;
 }
 
 export interface OtelGauges {
   /** Currently active sessions */
   activeSessions: UpDownCounter;
+  /** Currently active requests */
+  activeRequests: UpDownCounter;
+  /** Currently active agent turns */
+  activeAgentTurns: UpDownCounter;
 }
 
 // ── Init ────────────────────────────────────────────────────────────
@@ -411,6 +445,37 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       description: "Total sub-agent completion events",
       unit: "events",
     }),
+    // Queue metrics (ISI-1017)
+    queueLaneEnqueue: meter.createCounter("openclaw.queue.lane.enqueue", {
+      description: "Total queue lane enqueue events",
+      unit: "events",
+    }),
+    queueLaneDequeue: meter.createCounter("openclaw.queue.lane.dequeue", {
+      description: "Total queue lane dequeue events",
+      unit: "events",
+    }),
+    // Session metrics (ISI-1017)
+    sessionStuck: meter.createCounter("openclaw.session.stuck", {
+      description: "Total session stuck events",
+      unit: "events",
+    }),
+    sessionLongRunning: meter.createCounter("openclaw.session.long_running", {
+      description: "Total session long-running events",
+      unit: "events",
+    }),
+    sessionStalled: meter.createCounter("openclaw.session.stalled", {
+      description: "Total session stalled events",
+      unit: "events",
+    }),
+    // Gateway health metrics (ISI-1016)
+    livenessWarnings: meter.createCounter("openclaw.liveness.warnings", {
+      description: "Total liveness warning events",
+      unit: "events",
+    }),
+    diagnosticHeartbeats: meter.createCounter("openclaw.diagnostic.heartbeats", {
+      description: "Total diagnostic heartbeat events",
+      unit: "events",
+    }),
   };
 
   const toolDuration = meter.createHistogram("openclaw.tool.duration", {
@@ -445,12 +510,55 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       description: "Sub-agent duration",
       unit: "ms",
     }),
+    // Queue histograms (ISI-1017)
+    queueDepth: meter.createHistogram("openclaw.queue.depth", {
+      description: "Queue depth",
+      unit: "items",
+    }),
+    queueWaitMs: meter.createHistogram("openclaw.queue.wait_ms", {
+      description: "Queue wait time",
+      unit: "ms",
+    }),
+    // Session histograms (ISI-1017)
+    sessionStuckAgeMs: meter.createHistogram("openclaw.session.stuck_age_ms", {
+      description: "Session stuck age",
+      unit: "ms",
+    }),
+    // Gateway health histograms (ISI-1016)
+    gatewayEventLoopDelayP99: meter.createHistogram("openclaw.gateway.event_loop_delay_p99", {
+      description: "Gateway event loop delay p99",
+      unit: "ms",
+    }),
+    gatewayEventLoopDelayMax: meter.createHistogram("openclaw.gateway.event_loop_delay_max", {
+      description: "Gateway event loop delay max",
+      unit: "ms",
+    }),
+    gatewayEventLoopUtilization: meter.createHistogram("openclaw.gateway.event_loop_utilization", {
+      description: "Gateway event loop utilization",
+      unit: "1",
+    }),
+    gatewayCpuCoreRatio: meter.createHistogram("openclaw.gateway.cpu_core_ratio", {
+      description: "Gateway CPU core ratio",
+      unit: "1",
+    }),
+    gatewayWorkQueued: meter.createHistogram("openclaw.gateway.work_queued", {
+      description: "Gateway work queued",
+      unit: "items",
+    }),
   };
 
   const gauges: OtelGauges = {
     activeSessions: meter.createUpDownCounter("openclaw.sessions.active", {
       description: "Currently active sessions",
       unit: "sessions",
+    }),
+    activeRequests: meter.createUpDownCounter("openclaw.requests.active", {
+      description: "Currently active requests",
+      unit: "requests",
+    }),
+    activeAgentTurns: meter.createUpDownCounter("openclaw.agent_turns.active", {
+      description: "Currently active agent turns",
+      unit: "turns",
     }),
   };
 


### PR DESCRIPTION
Add diagnostic event handlers for queue and session metrics:
- queue.lane.enqueue/dequeue counters with depth/wait histograms
- session.stuck/long_running/stalled counters with age histograms
- New gauges: activeRequests, activeAgentTurns

Also includes gateway health histograms from ISI-1016:
- event_loop_delay_p99/max, utilization, cpu_core_ratio, work_queued