### PR TITLE
feat(ISI-1018): add context layer and skill usage tracking

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -187,6 +187,20 @@ export async function registerDiagnosticsListener(
       counters.tokensTotal.add(usage.total, metricAttrs);
     }
 
+    // ISI-1018: Token breakdown by type (system, user, tool_result, skill)
+    if (usage.system) {
+      counters.tokensSystem.add(usage.system, metricAttrs);
+    }
+    if (usage.user) {
+      counters.tokensUser.add(usage.user, metricAttrs);
+    }
+    if (usage.toolResult) {
+      counters.tokensToolResult.add(usage.toolResult, metricAttrs);
+    }
+    if (usage.skill) {
+      counters.tokensSkill.add(usage.skill, metricAttrs);
+    }
+
     // Record cost metric
     if (typeof costUsd === "number" && costUsd > 0) {
       telemetry.meter.createCounter("openclaw.llm.cost.usd", {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -560,6 +560,7 @@ export function registerHooks(
       try {
         const tel = getTelemetry();
         if (!tel) return undefined;
+        const { histograms } = tel;
         const sessionKey = ctx?.sessionKey || "unknown";
         const sessionCtx = store.getActiveContext(sessionKey);
         const agentSpan = sessionCtx?.agentSpan;
@@ -572,6 +573,41 @@ export function registerHooks(
 
         agentSpan.setAttribute("openclaw.prompt.chars", prompt.length);
         agentSpan.setAttribute("openclaw.session.message_count", messagesArr.length);
+
+        // ISI-1018: Context layer and skill usage tracking
+        // Track skills loaded into the context
+        const skills = event?.skills || event?.context?.skills || [];
+        if (Array.isArray(skills) && skills.length > 0) {
+          agentSpan.setAttribute("openclaw.context.skill_count", skills.length);
+          const skillNames = skills
+            .map((s: any) => typeof s === "string" ? s : s?.name || s?.id)
+            .filter(Boolean)
+            .slice(0, 20); // Cap to avoid attribute explosion
+          if (skillNames.length > 0) {
+            agentSpan.setAttribute("openclaw.context.skill_names", skillNames);
+          }
+        }
+
+        // Track context window usage if available
+        const contextLimit = event?.contextLimit || event?.context?.limit;
+        const contextUsed = event?.contextUsed || event?.context?.used;
+        if (typeof contextLimit === "number") {
+          agentSpan.setAttribute("openclaw.context.limit", contextLimit);
+        }
+        if (typeof contextUsed === "number") {
+          agentSpan.setAttribute("openclaw.context.used", contextUsed);
+        }
+        if (typeof contextLimit === "number" && typeof contextUsed === "number") {
+          agentSpan.setAttribute("openclaw.context.utilization", contextUsed / contextLimit);
+        }
+
+        // ISI-1018: Context build duration
+        const contextBuildDuration = event?.contextBuildDuration || event?.durationMs;
+        if (typeof contextBuildDuration === "number") {
+          histograms.contextBuildDuration.record(contextBuildDuration, {
+            "openclaw.session.key": sessionKey,
+          });
+        }
 
         // Content capture (ISI-1000).
         captureContentAttribute(

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -597,7 +597,11 @@ export function registerHooks(
         if (typeof contextUsed === "number") {
           agentSpan.setAttribute("openclaw.context.used", contextUsed);
         }
-        if (typeof contextLimit === "number" && typeof contextUsed === "number") {
+        if (
+          typeof contextLimit === "number" &&
+          contextLimit > 0 &&
+          typeof contextUsed === "number"
+        ) {
           agentSpan.setAttribute("openclaw.context.utilization", contextUsed / contextLimit);
         }
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -185,6 +185,14 @@ export interface OtelCounters {
   livenessWarnings: Counter;
   /** Diagnostic heartbeat events */
   diagnosticHeartbeats: Counter;
+  /** System prompt tokens */
+  tokensSystem: Counter;
+  /** User message tokens */
+  tokensUser: Counter;
+  /** Tool result tokens */
+  tokensToolResult: Counter;
+  /** Skill tokens */
+  tokensSkill: Counter;
 }
 
 export interface OtelHistograms {
@@ -220,6 +228,8 @@ export interface OtelHistograms {
   gatewayCpuCoreRatio: Histogram;
   /** Gateway work queued */
   gatewayWorkQueued: Histogram;
+  /** Context build duration in ms */
+  contextBuildDuration: Histogram;
 }
 
 export interface OtelGauges {
@@ -476,6 +486,23 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       description: "Total diagnostic heartbeat events",
       unit: "events",
     }),
+    // Token breakdown by type (ISI-1018)
+    tokensSystem: meter.createCounter("openclaw.llm.tokens.system", {
+      description: "System prompt tokens",
+      unit: "tokens",
+    }),
+    tokensUser: meter.createCounter("openclaw.llm.tokens.user", {
+      description: "User message tokens",
+      unit: "tokens",
+    }),
+    tokensToolResult: meter.createCounter("openclaw.llm.tokens.tool_result", {
+      description: "Tool result tokens",
+      unit: "tokens",
+    }),
+    tokensSkill: meter.createCounter("openclaw.llm.tokens.skill", {
+      description: "Skill tokens",
+      unit: "tokens",
+    }),
   };
 
   const toolDuration = meter.createHistogram("openclaw.tool.duration", {
@@ -544,6 +571,11 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
     gatewayWorkQueued: meter.createHistogram("openclaw.gateway.work_queued", {
       description: "Gateway work queued",
       unit: "items",
+    }),
+    // Context build duration (ISI-1018)
+    contextBuildDuration: meter.createHistogram("openclaw.context.build_duration", {
+      description: "Context build duration",
+      unit: "ms",
     }),
   };
 


### PR DESCRIPTION
Add context layer observability:
- Track skills loaded into context (count, names)
- Track context window usage (limit, used, utilization)
- Add context build duration histogram
- Add token breakdown by type: system, user, tool_result, skill

New metrics:
- Counters: tokensSystem, tokensUser, tokensToolResult, tokensSkill
- Histogram: contextBuildDuration