### PR TITLE
fix(diagnostics): portable internal diagnostic events loader

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,9 @@
   "description": "Traces, metrics, and logs for OpenClaw using OpenLLMetry and OpenTelemetry",
   "version": "0.6.0",
   "minOpenClawVersion": "2026.4.21",
+  "contracts": {
+    "tools": ["otel_status"]
+  },
   "uiHints": {
     "endpoint": {
       "label": "OTLP Endpoint",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -7,6 +7,11 @@
   "contracts": {
     "tools": ["otel_status"]
   },
+  "toolMetadata": {
+    "otel_status": {
+      "optional": true
+    }
+  },
   "uiHints": {
     "endpoint": {
       "label": "OTLP Endpoint",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -8,6 +8,9 @@
  */
 
 import type { Span } from "@opentelemetry/api";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import type { TelemetryRuntime } from "./telemetry.js";
 import {
   GEN_AI_CONVERSATION_ID,
@@ -44,26 +47,100 @@ async function loadSdk(): Promise<void> {
   }
 }
 
+type DiagnosticEventSource = (listener: (evt: any) => void) => () => void;
+type DiagnosticsLogger = { debug?: (message: string) => void };
+
 // Direct access to internal diagnostic events (preferred - bypasses SDK wrapper)
-let onInternalDiagnosticEvent: ((listener: (evt: any) => void) => () => void) | null = null;
+let onInternalDiagnosticEvent: DiagnosticEventSource | null = null;
 let internalLoadAttempted = false;
 
-async function loadInternalDiagnostics(): Promise<void> {
+function safeRealpath(file: string): string {
+  try {
+    return fs.realpathSync(file);
+  } catch {
+    return path.resolve(file);
+  }
+}
+
+function resolveInternalDiagnosticsDistCandidates(entryFile: string | undefined): string[] {
+  if (!entryFile) return [];
+  const resolvedEntry = safeRealpath(entryFile);
+  const entryDir = path.dirname(resolvedEntry);
+  const entryParent = path.basename(entryDir);
+  const installRoot = entryParent === "dist" || entryParent === "src"
+    ? path.dirname(entryDir)
+    : entryDir;
+  const candidates = entryParent === "dist"
+    ? [entryDir]
+    : [path.join(installRoot, "dist"), entryDir];
+  return [...new Set(candidates)];
+}
+
+function findInternalDiagnosticsChunks(
+  distCandidates: string[],
+): Array<{ distDir: string; chunk: string }> {
+  const matches: Array<{ distDir: string; chunk: string }> = [];
+  for (const distDir of distCandidates) {
+    let files: string[];
+    try {
+      files = fs.readdirSync(distDir);
+    } catch {
+      continue;
+    }
+    const chunks = files
+      .filter((f) => f.startsWith("diagnostic-events-") && f.endsWith(".js"))
+      .sort();
+    for (const file of chunks) {
+      matches.push({ distDir, chunk: file });
+    }
+  }
+  return matches;
+}
+
+function resolveInternalDiagnosticEventSource(diag: Record<string, unknown>): DiagnosticEventSource | null {
+  const direct = diag.onInternalDiagnosticEvent;
+  if (typeof direct === "function") return direct as DiagnosticEventSource;
+  const named = Object.values(diag).find(
+    (value) => typeof value === "function" && value.name === "onInternalDiagnosticEvent",
+  );
+  return typeof named === "function" ? named as DiagnosticEventSource : null;
+}
+
+async function loadInternalDiagnosticEventSource(
+  entryFile: string | undefined,
+  logger?: DiagnosticsLogger,
+): Promise<DiagnosticEventSource | null> {
+  const matches = findInternalDiagnosticsChunks(resolveInternalDiagnosticsDistCandidates(entryFile));
+  if (matches.length === 0) {
+    logger?.debug?.("[otel] Internal diagnostics chunk not found; falling back to SDK diagnostics");
+    return null;
+  }
+
+  for (const [index, match] of matches.entries()) {
+    const fallbackAction = index === matches.length - 1
+      ? "falling back to SDK diagnostics"
+      : "trying next diagnostics chunk";
+    try {
+      const specifier = pathToFileURL(path.join(match.distDir, match.chunk)).href;
+      const diag = await import(specifier) as Record<string, unknown>;
+      const eventSource = resolveInternalDiagnosticEventSource(diag);
+      if (eventSource) return eventSource;
+      logger?.debug?.(
+        `[otel] Internal diagnostics chunk ${match.chunk} loaded but onInternalDiagnosticEvent export not resolved; ${fallbackAction}`,
+      );
+    } catch {
+      logger?.debug?.(
+        `[otel] Internal diagnostics chunk ${match.chunk} failed to load; ${fallbackAction}`,
+      );
+    }
+  }
+  return null;
+}
+
+async function loadInternalDiagnostics(logger?: DiagnosticsLogger): Promise<void> {
   if (internalLoadAttempted) return;
   internalLoadAttempted = true;
-  try {
-    const fs = await import("fs");
-    const path = await import("path");
-    const ocDist = path.dirname(process.argv[1]);
-    const chunk = fs.readdirSync(ocDist).find((f: string) => f.startsWith("diagnostic-events-") && f.endsWith(".js"));
-    if (!chunk) return;
-    const diag = await import(path.join(ocDist, chunk)) as any;
-    onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent
-      ?? Object.values(diag).find((v: any) => typeof v === "function" && v.name === "onInternalDiagnosticEvent") as any
-      ?? null;
-  } catch {
-    // Internal module not available
-  }
+  onInternalDiagnosticEvent = await loadInternalDiagnosticEventSource(process.argv[1], logger);
 }
 
 /** Pending usage data waiting to be attached to spans */
@@ -101,7 +178,7 @@ export async function registerDiagnosticsListener(
 ): Promise<() => void> {
   // Load the SDK if not already loaded
   await loadSdk();
-  await loadInternalDiagnostics();
+  await loadInternalDiagnostics(logger);
 
   // Use internal diagnostic events if available, otherwise fall back to SDK
   const eventSource = onInternalDiagnosticEvent || onDiagnosticEvent;
@@ -382,7 +459,7 @@ export function enrichSpanWithUsage(span: Span, data: PendingUsageData): void {
  * Note: Only accurate after registerDiagnosticsListener() has been called.
  */
 export function hasDiagnosticsSupport(): boolean {
-  return onDiagnosticEvent !== null;
+  return onInternalDiagnosticEvent !== null || onDiagnosticEvent !== null;
 }
 
 /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -52,10 +52,15 @@ async function loadInternalDiagnostics(): Promise<void> {
   if (internalLoadAttempted) return;
   internalLoadAttempted = true;
   try {
-    // Try to load from the internal module directly (use absolute path)
-    // @ts-ignore
-    const diag = await import("/home/hrexed/.npm-global/lib/node_modules/openclaw/dist/diagnostic-events-CjwOn-Qj.js") as any;
-    onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent || diag.o;
+    const fs = await import("fs");
+    const path = await import("path");
+    const ocDist = path.dirname(process.argv[1]);
+    const chunk = fs.readdirSync(ocDist).find((f: string) => f.startsWith("diagnostic-events-") && f.endsWith(".js"));
+    if (!chunk) return;
+    const diag = await import(path.join(ocDist, chunk)) as any;
+    onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent
+      ?? Object.values(diag).find((v: any) => typeof v === "function" && v.name === "onInternalDiagnosticEvent") as any
+      ?? null;
   } catch {
     // Internal module not available
   }

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,0 +1,296 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const roots: string[] = [];
+
+function makeInstallRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-otel-diag-"));
+  roots.push(root);
+  mkdirSync(path.join(root, "dist"), { recursive: true });
+  writeFileSync(path.join(root, "openclaw.mjs"), "await import('./dist/entry.js');\n");
+  writeFileSync(path.join(root, "dist", "entry.js"), "export {};\n");
+  return root;
+}
+
+function writeChunk(root: string, source: string, chunkName?: string): string {
+  const chunk = chunkName ?? `diagnostic-events-${path.basename(root).replace(/\W/g, "")}.js`;
+  writeFileSync(path.join(root, "dist", chunk), source);
+  return chunk;
+}
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+function createCounter() {
+  return { add: vi.fn() };
+}
+
+function createHistogram() {
+  return { record: vi.fn() };
+}
+
+function createTelemetry() {
+  return {
+    counters: {
+      llmRequests: createCounter(),
+      tokensCompletion: createCounter(),
+      tokensPrompt: createCounter(),
+      tokensSkill: createCounter(),
+      tokensSystem: createCounter(),
+      tokensToolResult: createCounter(),
+      tokensTotal: createCounter(),
+      tokensUser: createCounter(),
+    },
+    histograms: {
+      genAiOperationDuration: createHistogram(),
+      genAiTokenUsage: createHistogram(),
+      llmDuration: createHistogram(),
+    },
+    meter: {
+      createCounter: vi.fn(() => createCounter()),
+    },
+  };
+}
+
+async function loadFreshDiagnostics() {
+  vi.resetModules();
+  return import("../src/diagnostics.js");
+}
+
+async function withArgvEntry<T>(entryFile: string, run: () => Promise<T>): Promise<T> {
+  const previous = process.argv[1];
+  process.argv[1] = entryFile;
+  try {
+    return await run();
+  } finally {
+    process.argv[1] = previous;
+  }
+}
+
+async function registerWithEntry(
+  entryFile: string,
+  logger = createLogger(),
+  telemetry = createTelemetry(),
+) {
+  const diagnostics = await loadFreshDiagnostics();
+  const unsubscribe = await withArgvEntry(entryFile, () =>
+    diagnostics.registerDiagnosticsListener(telemetry as any, logger),
+  );
+  return { diagnostics, logger, unsubscribe };
+}
+
+afterEach(() => {
+  while (roots.length > 0) {
+    rmSync(roots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("internal diagnostics loader path resolution", () => {
+  it("loads from package-root dist for the packaged openclaw.mjs launcher", async () => {
+    const root = makeInstallRoot();
+    writeChunk(
+      root,
+      "function onInternalDiagnosticEvent() { return () => undefined; }\nexport { onInternalDiagnosticEvent as o };\n",
+    );
+
+    const { diagnostics, logger, unsubscribe } = await registerWithEntry(
+      path.join(root, "openclaw.mjs"),
+    );
+
+    expect(unsubscribe).toEqual(expect.any(Function));
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      "[otel] No diagnostic event source available — using fallback token extraction",
+    );
+  });
+
+  it("loads directly from dist/entry.js launchers", async () => {
+    const root = makeInstallRoot();
+    writeChunk(root, "export function onInternalDiagnosticEvent() { return () => undefined; }\n");
+
+    const { diagnostics } = await registerWithEntry(path.join(root, "dist", "entry.js"));
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+  });
+
+  it("loads from install-root dist for source-checkout src/entry.ts launchers", async () => {
+    const root = makeInstallRoot();
+    const src = path.join(root, "src");
+    mkdirSync(src);
+    writeFileSync(path.join(src, "entry.ts"), "export {};\n");
+    writeChunk(root, "export function onInternalDiagnosticEvent() { return () => undefined; }\n");
+
+    const { diagnostics } = await registerWithEntry(path.join(src, "entry.ts"));
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+  });
+
+  it("follows symlinked bin launchers before deriving the dist directory", async () => {
+    const root = makeInstallRoot();
+    const bin = path.join(root, "bin");
+    mkdirSync(bin);
+    const link = path.join(bin, "openclaw");
+    symlinkSync(path.join(root, "openclaw.mjs"), link);
+    writeChunk(root, "export function onInternalDiagnosticEvent() { return () => undefined; }\n");
+
+    const { diagnostics } = await registerWithEntry(link);
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+  });
+
+  it("ignores non-JavaScript diagnostic event declarations", async () => {
+    const root = makeInstallRoot();
+    writeFileSync(path.join(root, "dist", "diagnostic-events-types.d.ts"), "export {};\n");
+    writeChunk(root, "export function onInternalDiagnosticEvent() { return () => undefined; }\n");
+
+    const { diagnostics } = await registerWithEntry(path.join(root, "openclaw.mjs"));
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+  });
+});
+
+describe("internal diagnostics export resolution", () => {
+  it("uses the direct public export when present", async () => {
+    const root = makeInstallRoot();
+    writeChunk(root, "export function onInternalDiagnosticEvent() { return () => undefined; }\n");
+
+    const { diagnostics } = await registerWithEntry(path.join(root, "openclaw.mjs"));
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+  });
+
+  it("uses the function name when the export alias is minified", async () => {
+    const root = makeInstallRoot();
+    writeChunk(
+      root,
+      "function onInternalDiagnosticEvent() { return () => undefined; }\nexport { onInternalDiagnosticEvent as o };\n",
+    );
+
+    const { diagnostics } = await registerWithEntry(path.join(root, "openclaw.mjs"));
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+  });
+
+  it("receives model usage events from the resolved internal source", async () => {
+    const root = makeInstallRoot();
+    writeChunk(
+      root,
+      `export function onInternalDiagnosticEvent(listener) {
+        listener({
+          type: "model.usage",
+          sessionKey: "session-1",
+          provider: "openai",
+          model: "gpt-test",
+          usage: { input: 11, output: 5, total: 16 },
+          costUsd: 0.12,
+          durationMs: 123,
+          context: { limit: 200, used: 16 }
+        });
+        return () => undefined;
+      }\n`,
+    );
+    const logger = createLogger();
+    const telemetry = createTelemetry();
+
+    const { diagnostics } = await registerWithEntry(
+      path.join(root, "openclaw.mjs"),
+      logger,
+      telemetry,
+    );
+
+    expect(diagnostics.getPendingUsage("session-1")).toMatchObject({
+      costUsd: 0.12,
+      durationMs: 123,
+      model: "gpt-test",
+      provider: "openai",
+      usage: { input: 11, output: 5, total: 16 },
+      context: { limit: 200, used: 16 },
+    });
+    expect(telemetry.counters.tokensPrompt.add).toHaveBeenCalledWith(11, expect.any(Object));
+    expect(telemetry.counters.tokensCompletion.add).toHaveBeenCalledWith(5, expect.any(Object));
+    expect(telemetry.counters.tokensTotal.add).toHaveBeenCalledWith(16, expect.any(Object));
+    expect(telemetry.counters.llmRequests.add).toHaveBeenCalledWith(1, expect.any(Object));
+    expect(telemetry.histograms.llmDuration.record).toHaveBeenCalledWith(123, expect.any(Object));
+    expect(telemetry.histograms.genAiOperationDuration.record).toHaveBeenCalledWith(0.123, expect.any(Object));
+    expect(telemetry.meter.createCounter).toHaveBeenCalledWith(
+      "openclaw.llm.cost.usd",
+      expect.any(Object),
+    );
+  });
+
+  it("ignores non-function direct exports", async () => {
+    const root = makeInstallRoot();
+    writeChunk(root, "export const onInternalDiagnosticEvent = 'not-a-function';\n");
+    const logger = createLogger();
+
+    const { diagnostics } = await registerWithEntry(path.join(root, "openclaw.mjs"), logger);
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(false);
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("loaded but onInternalDiagnosticEvent export not resolved"),
+    );
+  });
+});
+
+describe("internal diagnostics fallback logging", () => {
+  it("tries later chunks when an earlier diagnostics chunk has no event export", async () => {
+    const root = makeInstallRoot();
+    writeChunk(root, "export function emitFailoverEvent() {}\n", "diagnostic-events-a.js");
+    writeChunk(
+      root,
+      "export function onInternalDiagnosticEvent() { return () => undefined; }\n",
+      "diagnostic-events-z.js",
+    );
+    const logger = createLogger();
+
+    const { diagnostics } = await registerWithEntry(path.join(root, "openclaw.mjs"), logger);
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+    expect(logger.debug).toHaveBeenCalledWith(
+      "[otel] Internal diagnostics chunk diagnostic-events-a.js loaded but onInternalDiagnosticEvent export not resolved; trying next diagnostics chunk",
+    );
+  });
+
+  it("logs when a chunk loads but the event export cannot be resolved", async () => {
+    const root = makeInstallRoot();
+    const chunk = writeChunk(root, "export function emitFailoverEvent() {}\n");
+    const logger = createLogger();
+
+    await registerWithEntry(path.join(root, "openclaw.mjs"), logger);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      `[otel] Internal diagnostics chunk ${chunk} loaded but onInternalDiagnosticEvent export not resolved; falling back to SDK diagnostics`,
+    );
+  });
+
+  it("logs when no diagnostics chunk exists in the resolved candidates", async () => {
+    const root = makeInstallRoot();
+    const logger = createLogger();
+
+    await registerWithEntry(path.join(root, "openclaw.mjs"), logger);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      "[otel] Internal diagnostics chunk not found; falling back to SDK diagnostics",
+    );
+  });
+
+  it("logs when the diagnostics chunk cannot be imported", async () => {
+    const root = makeInstallRoot();
+    const chunk = writeChunk(root, "throw new Error('boom');\n");
+    const logger = createLogger();
+
+    await registerWithEntry(path.join(root, "openclaw.mjs"), logger);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      `[otel] Internal diagnostics chunk ${chunk} failed to load; falling back to SDK diagnostics`,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`loadInternalDiagnostics()` in v0.6.0 had a hardcoded absolute path and chunk hash from the maintainer's dev environment:

```typescript
const diag = await import("/home/hrexed/.npm-global/lib/node_modules/openclaw/dist/diagnostic-events-CjwOn-Qj.js") as any;
onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent || diag.o;
```

That fails silently anywhere else because the install path, generated chunk hash, and minified export alias can all differ by host/build. When the internal loader misses, the plugin falls back to the SDK wrapper, where current OpenClaw builds can map the wrong minified export as `onDiagnosticEvent` and then fail on gateway stop/restart.

## Change

This replaces the hardcoded internal loader with a portable, defensive resolver that:

- prefers the stable `openclaw/plugin-sdk/diagnostic-runtime` export when present
- follows `process.argv[1]` through `realpath` before deriving candidate install directories for older builds
- supports package-root launchers such as `openclaw.mjs`, direct `dist/*` entrypoints, source-checkout `src/*` entrypoints, and symlinked bin launchers
- discovers `diagnostic-events-*.js` chunks dynamically and imports them via `pathToFileURL`
- resolves `onInternalDiagnosticEvent` through the direct export, a known minified listener alias, a preserved function name, or a validated listener-shaped export
- tries later matching chunks when an earlier chunk cannot provide the event source
- emits debug logs for missing chunks, failed chunk imports, and chunks that load but do not expose `onInternalDiagnosticEvent`
- treats the internal event source as diagnostics support in `hasDiagnosticsSupport()`

The manifest now declares both `contracts.tools: ["otel_status"]` and `toolMetadata.otel_status.optional: true`, matching the runtime `api.registerTool(..., { optional: true })` registration.

## Testing

Current head: `d39856556d70f127bf2caf3e68a7282190c02e2b`.

Passed locally after merging current `main` and resolving conflicts:

- `npm test` - 12 test files, 267 tests passing
- `npx vitest run tests/diagnostics.test.ts` - 15 tests passing
- `npm run typecheck`
- `npm run lint`
- `node -e "JSON.parse(require('fs').readFileSync('openclaw.plugin.json','utf8')); console.log('openclaw.plugin.json ok')"`
- `git diff --check`

The diagnostics tests cover package-root launchers, direct `dist` entrypoints, source-checkout entrypoints, symlinked bin launchers, `.d.ts` chunk filtering, direct exports, minified alias resolution, listener-shape validation, multi-chunk fallback, missing/import-failed/no-export debug logs, and an emitted `model.usage` event flowing through `registerDiagnosticsListener()` into pending usage and metrics.

Review gates run:

- independent correctness review: no P0/P1/P2 findings after the final patch
- tests/proof review: one P2 found, addressed by adding the public-surface emitted `model.usage` regression test
- manifest/maintainability review: `otel_status` optional metadata matches the existing runtime tool registration

Prior runtime validation from the original PR remains relevant:

- Gateway startup: plugin loads cleanly, diagnostics subscribed via internal path
- Gateway stop: no `unsubscribeDiagnosticEvents is not a function` error
- 4 consecutive restart cycles: clean stop/start on every cycle
- `contracts.tools` warning: eliminated from startup logs
