### PR TITLE
fix: preserve TracerProvider across config hot-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ OpenClaw has two hook registration moments, and the plugin uses both at the righ
 
 | Phase | Runs | What the plugin does |
 |---|---|---|
-| `register()` | Synchronous, before the gateway accepts traffic | Registers **all V3 typed hooks** via `api.on()` (see list below), plus event-stream hooks (`command:*`, `gateway:startup`), the `otel-observability.status` RPC, the `otel` CLI command, the background service, and the optional `otel_status` agent tool. Hooks receive a **lazy telemetry getter** (`() => telemetry`) so they can be wired before the OTel runtime exists. |
+| `register()` | Synchronous, before the gateway accepts traffic | Initializes the OTel runtime, log pipeline, **all V3 typed hooks** via `api.on()` (see list below), event-stream hooks (`command:*`, `gateway:startup`), the `otel-observability.status` RPC, the `otel` CLI command, the background service, diagnostics listener, and optional `otel_status` agent tool. Hooks receive a **lazy telemetry getter** (`() => telemetry`) so existing handlers keep using the live runtime across hot reload. |
 
 <details>
 <summary>Typed hooks registered in <code>register()</code></summary>
@@ -159,10 +159,18 @@ OpenClaw has two hook registration moments, and the plugin uses both at the righ
 **Orchestration hooks:** cron hooks (`cron_change`, `cron_execution`, `cron_error`), subagent hooks (`subagent_spawn`, `subagent_ended`)
 
 </details>
-| `start()` | Async, after the gateway is ready | Calls `initTelemetry()` to build the `TracerProvider`/`MeterProvider` and register them globally, initializes the OTLP log export pipeline, conditionally initializes OpenLLMetry wraps when `traces` is on, and subscribes to OpenClaw diagnostic events (`model.usage`, `log.record`) for cost/token data and log forwarding. |
-| `stop()` | Async, on gateway reload/shutdown | Clears the stale-session sweeper `setInterval`, unsubscribes from diagnostics, shuts down the log pipeline, and calls `telemetry.shutdown()` to flush exporters. |
+| `start()` | Async, after the gateway is ready | Performs gateway-only work: publishes content-capture env vars for subprocesses, warns on preload/config mismatches, and conditionally initializes OpenLLMetry wraps when `traces` is on. |
+| `stop()` | Async, on gateway reload/shutdown | Clears the stale-session sweeper `setInterval`, unsubscribes from diagnostics, shuts down the log pipeline, and calls `telemetry.flush()` so pending spans/metrics drain without destroying providers. |
 
-**Why this matters:** OpenClaw snapshots typed hooks at registration time. If hooks are registered from `start()` instead of `register()`, the gateway never sees them and **hooks register but never fire**. PR #6 (see [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6)) moved them back to `register()` and introduced the lazy getter so handlers no-op cleanly during the brief `register()` → `start()` window.
+### Hot reload and final flush behavior
+
+OpenClaw config hot-reload calls `stop()` and then `register()` in the same process. The plugin treats `stop()` as a non-destructive drain: it calls `forceFlush()` on trace and metric providers, but keeps the providers alive so hooks that still reference the existing runtime continue to export telemetry after reload.
+
+That tradeoff preserves data, but trace/metric provider config changes do not rebuild the live providers until a full process restart. Changes to `endpoint`, `headers`, `protocol`, `serviceName`, `traces`, `metrics`, `sampleRate`, `metricsIntervalMs`, `resourceAttributes`, and preload-backed content capture can be parsed during reload, but the existing trace/metric runtime keeps using the values it was initialized with. Restart the gateway when changing those settings. The log pipeline is recreated on service `stop()`/`register()` reload, so `logs` and `logConfig` changes can take effect through the plugin reload path.
+
+For `--local` and other code paths that call `process.exit()` before the batch processor interval fires, the plugin publishes `globalThis[Symbol.for("openclaw.otel.preExit")]`. The plugin sets that symbol to a non-destructive flush function during telemetry initialization and clears it from `shutdown()`. CLI exit handlers own calling it before forced exit.
+
+**Why this matters:** OpenClaw snapshots typed hooks at registration time. If hooks are registered from `start()` instead of `register()`, the gateway never sees them and **hooks register but never fire**. PR #6 (see [ISI-515](https://github.com/henrikrexed/openclaw-observability-plugin/pull/6)) moved them back to `register()`, and current builds initialize telemetry in `register()` while using the lazy getter so hot-reload handlers keep resolving the live runtime.
 
 ### Installation
 
@@ -377,7 +385,9 @@ In your backend, look for an `openclaw.request` span with at least one `openclaw
 
 ## Configuration Reference
 
-### Official Plugin Options
+### Built-in OpenClaw Diagnostics Options
+
+These keys configure OpenClaw core's built-in diagnostics exporter. They are not the config surface for this custom hook-based plugin.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
@@ -390,24 +400,44 @@ In your backend, look for an `openclaw.request` span with at least one `openclaw
 | `diagnostics.otel.traces` | boolean | true | Enable traces |
 | `diagnostics.otel.metrics` | boolean | true | Enable metrics |
 | `diagnostics.otel.logs` | boolean | false | Enable logs |
-| `diagnostics.otel.sampleRate` | number | (unset) | Head-based trace sampling rate, 0.0–1.0. Wraps `TraceIdRatioBasedSampler` in `ParentBasedSampler` so child spans inherit the root decision. Omit (or use `1.0`) to keep all traces. **Overrides `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`** — the plugin builds the sampler directly and never reads those env vars; see [Trace Sampling](docs/configuration.md#trace-sampling) for precedence rules. |
+| `diagnostics.otel.sampleRate` | number | (unset) | Built-in diagnostics trace sampling, if supported by your OpenClaw version. This custom plugin uses `plugins.entries.otel-observability.config.sampleRate` below. |
 
 ### Custom Plugin Options
 
-> **Important:** Do NOT add a `config` block inside the plugin entry — OpenClaw's plugin framework rejects unknown properties. The plugin reads its configuration from the `diagnostics.otel` section instead.
+This plugin reads its settings from `plugins.entries.otel-observability.config`:
 
-The following settings are controlled via the `diagnostics.otel` config block:
+```json
+{
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "endpoint": "http://localhost:4318",
+          "protocol": "http",
+          "serviceName": "openclaw-gateway"
+        }
+      }
+    }
+  }
+}
+```
+
+The following settings are controlled via that plugin entry `config` block:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `endpoint` | string | `http://localhost:4318` | OTLP endpoint URL |
 | `serviceName` | string | `openclaw-gateway` | Service name |
-| `protocol` | string | `http/protobuf` | OTLP protocol (`http` or `grpc`) |
+| `protocol` | string | `http` | OTLP protocol (`http` or `grpc`) |
 | `traces` | boolean | true | Enable traces |
 | `metrics` | boolean | true | Enable metrics |
 | `logs` | boolean | true | Enable OTLP log export via diagnostic events |
 | `captureContent` | boolean \| `ContentCapturePolicy` | `false` (all off) | Capture prompt/completion/tool content on spans. Accepts a boolean (all-on or all-off, legacy) or a granular object with the per-category flags `inputMessages`, `outputMessages`, `toolInputs`, `toolOutputs`, `systemPrompt`. Privacy-sensitive — see [docs/security/privacy.md](./docs/security/privacy.md). |
 | `metricsIntervalMs` | number | 30000 | Metric export interval in milliseconds |
+| `sampleRate` | number | unset | Head-based trace sampling rate, 0.0-1.0. Omit to use the SDK default. |
+| `resourceAttributes` | object | `{}` | Extra OpenTelemetry resource attributes |
+| `logConfig` | object | unset | Log pipeline filtering and exclusion rules |
 
 ### Log Pipeline Configuration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,9 +135,11 @@ OpenClaw drives plugins through three phases. Mixing them up is the single most 
         │                     │                     │
         │                     │                     │
         ▼                     ▼                     ▼
-  - api.on(*)           - initTelemetry()    - stopHooks()
-  - api.registerHook()  - initOpenLLMetry()  - unsubscribe()
-  - api.registerGate…   - registerDiagnost… - telemetry.shutdown()
+  - initTelemetry()     - initOpenLLMetry()  - stopHooks()
+  - api.on(*)           - env bridge         - unsubscribe()
+  - api.registerHook()                       - telemetry.flush()
+  - api.registerGate…
+  - api.on("gateway_stop")
   - api.registerCli()
   - api.registerService()
   - api.registerTool()
@@ -148,32 +150,41 @@ OpenClaw drives plugins through three phases. Mixing them up is the single most 
 
 | Phase | Runs | Responsibility |
 |---|---|---|
-| `register()` | Synchronous, before the gateway accepts traffic | Wire every typed hook (`message_received`, `session_start`, `session_end`, `before_model_resolve`, `before_prompt_build`, `llm_input`, `llm_output`, `model_call_started`, `model_call_ended`, `before_dispatch`, `reply_dispatch`, `before_tool_call`, `after_tool_call`, `tool_approval_resolution`, `tool_result_persist`, `message_sent`, `before_agent_finalize`, `agent_end`, `before_reset`, cron hooks, subagent hooks), event-stream hooks (`command:*`, `gateway:startup`), RPC method, CLI command, background service, and agent tool. |
-| `start()` | Async, once the gateway is ready | Build the OTel runtime (`initTelemetry` → TracerProvider + MeterProvider), optionally wrap LLM SDKs with OpenLLMetry when `traces` is on, and subscribe to OpenClaw diagnostic events for cost/token data. |
-| `stop()` | Async, on gateway reload or shutdown | Clear the stale-session sweeper `setInterval` (see [b668a4f](https://github.com/henrikrexed/openclaw-observability-plugin/commit/b668a4f), ISI-522), unsubscribe from diagnostics, and call `telemetry.shutdown()` so batched spans/metrics flush before the process exits. |
+| `register()` | Synchronous, before the gateway accepts traffic | Build or reuse the OTel runtime (`initTelemetry` → TracerProvider + MeterProvider), wire every typed hook (`message_received`, `session_start`, `session_end`, `before_model_resolve`, `before_prompt_build`, `llm_input`, `llm_output`, `model_call_started`, `model_call_ended`, `before_dispatch`, `reply_dispatch`, `before_tool_call`, `after_tool_call`, `tool_approval_resolution`, `tool_result_persist`, `message_sent`, `before_agent_finalize`, `agent_end`, `before_reset`, cron hooks, subagent hooks), event-stream hooks (`command:*`, `gateway:startup`), diagnostics listener, RPC method, CLI command, background service, and agent tool. |
+| `start()` | Async, once the gateway is ready | Perform gateway-only setup: publish content-capture env vars for subprocesses, warn on preload/config mismatches, and optionally wrap LLM SDKs with OpenLLMetry when `traces` is on. |
+| `stop()` | Async, on gateway reload or shutdown | Clear the stale-session sweeper `setInterval` (see [b668a4f](https://github.com/henrikrexed/openclaw-observability-plugin/commit/b668a4f), ISI-522), unsubscribe from diagnostics, shut down the log pipeline, and call `telemetry.flush()` so batched spans/metrics drain without destroying providers. |
+| `gateway_stop` | Final gateway lifecycle hook | Calls `telemetry.shutdown()` for destructive provider teardown, clears the metric heartbeat interval and preExit symbol, and releases the module-level runtime guard for a real process restart. |
 
 ### Lazy telemetry getter
 
-Hooks need to be registered in `register()` — which is synchronous and runs before `initTelemetry()` — but they need to read an OTel runtime that only exists after `start()`. The plugin solves this by registering hooks with a **lazy telemetry getter** instead of a concrete runtime:
+Hooks are registered in `register()` and resolve the current runtime with a **lazy telemetry getter** instead of closing over a stale concrete runtime:
 
 ```typescript
 let telemetry: TelemetryRuntime | null = null;
 
 // Registered in register(), resolves telemetry at call time.
-let stopHooks = registerHooks(api, () => telemetry, config);
+let stopHooks: (() => void) | null = null;
+let unsubscribeDiagnostics: (() => void) | null = null;
+
+telemetry = initTelemetry(config, logger);         // populated in register()
+stopHooks = registerHooks(api, () => telemetry, config);
+registerDiagnosticsListener(telemetry, logger).then((unsub) => {
+  unsubscribeDiagnostics = unsub;
+});
+api.on("gateway_stop", async () => {
+  await telemetry?.shutdown();                     // destructive finalizer
+  telemetry = null;
+});
 
 api.registerService({
   id: "otel-observability",
   start: async () => {
-    telemetry = initTelemetry(config, logger);     // populated here
     if (config.traces) await initOpenLLMetry(config, logger);
-    unsubscribeDiagnostics = await registerDiagnosticsListener(telemetry, logger);
   },
   stop: async () => {
     stopHooks?.();                                  // clearInterval
     unsubscribeDiagnostics?.();
-    await telemetry?.shutdown();
-    telemetry = null;
+    await telemetry?.flush();                       // non-destructive
   },
 });
 ```
@@ -185,7 +196,15 @@ const telemetry = getTelemetry();
 if (!telemetry) return;
 ```
 
-so any hook that fires between `register()` and `start()` completing is a clean no-op. Once `initTelemetry()` runs, the next invocation sees a live runtime and begins emitting spans.
+so hook handlers read whichever live runtime `register()` installed.
+
+### Hot reload vs. final shutdown
+
+OpenClaw uses the same service `stop()` callback for config hot-reload and ordinary gateway teardown, and the service context does not provide a reliable "final process exit" discriminator. This plugin therefore treats `stop()` as a hot-reload-safe drain, not a destructive provider shutdown.
+
+`initTelemetry()` is idempotent. During hot reload, the new `register()` call reuses the existing runtime rather than registering a second global TracerProvider or duplicating the metric heartbeat interval. This prevents silent telemetry loss after reload, but it also means trace/metric provider config changes do not take effect until the process restarts. Restart the gateway after changing endpoint, headers, protocol, service name, traces, metrics, sample rate, metrics interval, resource attributes, or preload-backed content capture. The metric heartbeat interval is unref'ed so it does not pin process exit; `gateway_stop` still performs explicit destructive shutdown when the host emits final gateway teardown.
+
+The runtime still exposes `shutdown()` for explicit destructive teardown in tests and `gateway_stop`. During normal operation, forced-exit callers should use `globalThis[Symbol.for("openclaw.otel.preExit")]` to flush before `process.exit()`; the plugin sets that symbol during telemetry initialization and clears it from `shutdown()`.
 
 ### How It Works
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,26 +1,29 @@
 # Configuration
 
-Configure OpenClaw's built-in OpenTelemetry diagnostics via `~/.openclaw/openclaw.json`.
+Configure the custom hook-based OTel observability plugin via `~/.openclaw/openclaw.json`.
 
 ## Full Configuration Example
 
 ```json
 {
-  "diagnostics": {
-    "enabled": true,
-    "otel": {
-      "enabled": true,
-      "endpoint": "http://localhost:4318",
-      "protocol": "http/protobuf",
-      "headers": {
-        "Authorization": "Api-Token dt0c01.xxx"
-      },
-      "serviceName": "openclaw-gateway",
-      "traces": true,
-      "metrics": true,
-      "logs": true,
-      "sampleRate": 1.0,
-      "flushIntervalMs": 5000
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "endpoint": "http://localhost:4318",
+          "protocol": "http",
+          "headers": {
+            "Authorization": "Api-Token dt0c01.xxx"
+          },
+          "serviceName": "openclaw-gateway",
+          "traces": true,
+          "metrics": true,
+          "logs": true,
+          "sampleRate": 1.0,
+          "metricsIntervalMs": 30000
+        }
+      }
     }
   }
 }
@@ -28,30 +31,24 @@ Configure OpenClaw's built-in OpenTelemetry diagnostics via `~/.openclaw/opencla
 
 ## Configuration Reference
 
-### `diagnostics`
+### `plugins.entries.otel-observability.config`
 
-Top-level diagnostics configuration.
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable the diagnostics system |
-
-### `diagnostics.otel`
-
-OpenTelemetry export configuration.
+Plugin entry configuration.
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `enabled` | boolean | `false` | Enable OTel export |
-| `endpoint` | string | — | OTLP endpoint URL (required) |
-| `protocol` | string | `"http/protobuf"` | Protocol: `"http/protobuf"` or `"grpc"` |
+| `endpoint` | string | `"http://localhost:4318"` | OTLP endpoint URL |
+| `protocol` | string | `"http"` | Protocol: `"http"` or `"grpc"` |
 | `headers` | object | `{}` | Custom HTTP headers (e.g., auth tokens) |
-| `serviceName` | string | `"openclaw"` | OTel service name attribute |
+| `serviceName` | string | `"openclaw-gateway"` | OTel service name attribute |
 | `traces` | boolean | `true` | Enable trace export |
 | `metrics` | boolean | `true` | Enable metrics export |
-| `logs` | boolean | `false` | Enable log forwarding |
+| `logs` | boolean | `true` | Enable log forwarding |
 | `sampleRate` | number | — | Trace sampling rate, `0.0`–`1.0`. Omit to use the SDK default (`parentbased_always_on`). **Overrides `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG`** — see [Trace Sampling](#trace-sampling) for precedence rules. |
-| `flushIntervalMs` | number | — | Export flush interval in milliseconds |
+| `metricsIntervalMs` | number | `30000` | Metrics export interval in milliseconds |
+| `captureContent` | boolean \| object | `false` | Span content capture policy |
+| `resourceAttributes` | object | `{}` | Extra OpenTelemetry resource attributes |
+| `logConfig` | object | — | Log filtering and exclusion rules |
 
 ## Endpoint Configuration
 
@@ -61,12 +58,15 @@ For OTLP/HTTP endpoints (port 4318):
 
 ```json
 {
-  "diagnostics": {
-    "enabled": true,
-    "otel": {
-      "enabled": true,
-      "endpoint": "http://localhost:4318",
-      "protocol": "http/protobuf"
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "endpoint": "http://localhost:4318",
+          "protocol": "http"
+        }
+      }
     }
   }
 }
@@ -80,12 +80,15 @@ For OTLP/gRPC endpoints (port 4317):
 
 ```json
 {
-  "diagnostics": {
-    "enabled": true,
-    "otel": {
-      "enabled": true,
-      "endpoint": "http://localhost:4317",
-      "protocol": "grpc"
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "endpoint": "http://localhost:4317",
+          "protocol": "grpc"
+        }
+      }
     }
   }
 }
@@ -152,12 +155,15 @@ Control trace sampling rate to reduce volume:
 
 ```json
 {
-  "diagnostics": {
-    "enabled": true,
-    "otel": {
-      "enabled": true,
-      "endpoint": "http://localhost:4318",
-      "sampleRate": 0.1
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "endpoint": "http://localhost:4318",
+          "sampleRate": 0.1
+        }
+      }
     }
   }
 }
@@ -243,9 +249,14 @@ The plugin exports 100% of traces by default. For high-traffic gateways this can
 
 ```json
 {
-  "diagnostics": {
-    "otel": {
-      "sampleRate": 0.1
+  "plugins": {
+    "entries": {
+      "otel-observability": {
+        "enabled": true,
+        "config": {
+          "sampleRate": 0.1
+        }
+      }
     }
   }
 }
@@ -266,7 +277,7 @@ Invalid values (negative, > 1, `NaN`, non-numeric, `null`, plain object) are ign
 
 OpenTelemetry SDKs typically read the `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` environment variables to choose a default sampler. **This plugin does not.** When `sampleRate` is set in plugin config, the plugin builds the sampler directly (`ParentBased(TraceIdRatio(sampleRate))`) and the env vars have no effect on the plugin's tracer provider. When `sampleRate` is omitted, the plugin omits the `sampler` key entirely so the SDK's default (`parentbased_always_on`) applies — and even in that case, the plugin does not propagate `OTEL_TRACES_SAMPLER` to its provider.
 
-Operators migrating from other OTel SDKs should configure sampling via `diagnostics.otel.sampleRate` rather than the env vars. The precedence is:
+Operators migrating from other OTel SDKs should configure sampling via `plugins.entries.otel-observability.config.sampleRate` rather than the env vars. The precedence is:
 
 | Configuration                                                  | Effective sampler                                          |
 | -------------------------------------------------------------- | ---------------------------------------------------------- |
@@ -299,6 +310,34 @@ LLM-client spans emitted by Traceloop (`@traceloop/instrumentation-anthropic`, `
 ### Not hot-reloadable
 
 `captureContent` is a **gateway-launch setting**, not a hot-reloadable plugin option, because the ESM preload (`instrumentation/preload.mjs`) instantiates `AnthropicInstrumentation` and `OpenAIInstrumentation` *before* OpenClaw parses plugin config. Changing the value in `openclaw.json` mid-run has no effect until the next gateway restart.
+
+The telemetry providers themselves are also preserved across config hot-reload. OpenClaw calls the plugin service `stop()` before `register()` during reload; this plugin treats `stop()` as a non-destructive drain and calls `forceFlush()` instead of `shutdown()` so the live TracerProvider/MeterProvider keep exporting spans and metrics after reload.
+
+Because the runtime is reused, changes to telemetry-affecting fields do not take effect until a full gateway restart:
+
+- `endpoint`
+- `headers`
+- `protocol`
+- `serviceName`
+- `traces`
+- `metrics`
+- `sampleRate`
+- `metricsIntervalMs`
+- `resourceAttributes`
+- preload-backed content capture (`captureContent` for Traceloop LLM-client spans)
+
+This is intentional: stale telemetry config is preferable to dropping all post-reload spans. Restart the gateway after changing any of those fields. The log pipeline is rebuilt during service `stop()`/`register()` reloads, so `logs` and `logConfig` can take effect through the plugin reload path.
+
+### `openclaw.otel.preExit`
+
+The plugin publishes a loose pre-exit contract for OpenClaw code paths that call `process.exit()` before the BatchSpanProcessor export interval fires:
+
+```typescript
+const preExit = globalThis[Symbol.for("openclaw.otel.preExit")];
+if (typeof preExit === "function") await preExit();
+```
+
+The plugin sets the symbol to a non-destructive flush function during telemetry initialization and clears it from `shutdown()`. CLI exit handlers own calling it before forced exit.
 
 ### How to enable content capture
 
@@ -387,17 +426,13 @@ Leave `captureContent` at `false` unless you control the backend and understand 
 
 ## Applying Changes
 
-After modifying configuration:
+After modifying trace/metric provider configuration:
 
 ```bash
 openclaw gateway restart
 ```
 
-Or trigger a hot reload (if supported):
-
-```bash
-kill -SIGUSR1 $(pgrep -f openclaw-gateway)
-```
+Plugin hot reload can apply log pipeline changes (`logs` and `logConfig`), but it does not rebuild the trace or metric providers listed above.
 
 ## Troubleshooting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,11 @@ Add to your `~/.openclaw/openclaw.json`:
     "entries": {
       "otel-observability": {
         "enabled": true,
+        "config": {
+          "endpoint": "http://localhost:4318",
+          "protocol": "http",
+          "serviceName": "openclaw-gateway"
+        },
         "hooks": {
           "allowConversationAccess": true
         }
@@ -91,7 +96,7 @@ Add to your `~/.openclaw/openclaw.json`:
 
 > **Required for OpenClaw ≥ 2026.4.23.** Path-loaded (non-bundled) plugins must explicitly opt in to conversation typed hooks. Without `hooks.allowConversationAccess: true`, OpenClaw silently drops the registrations for `before_model_resolve`, `llm_input`, `llm_output`, `before_agent_finalize`, `agent_end`, `before_agent_reply`, and `before_agent_run`. The plugin still prints its `[otel] Registered ... hook (via api.on)` banners but the handlers never fire, so no `openclaw.request` / `openclaw.agent.turn` spans reach your backend. See [github issue #20](https://github.com/henrikrexed/openclaw-observability-plugin/issues/20) and the [troubleshooting section](../README.md#hooks-register-but-never-fire).
 
-> **Note:** Do NOT add a `config` block inside `otel-observability` — OpenClaw's plugin framework rejects unknown properties. The plugin reads its settings from the `diagnostics.otel` section instead. If you need custom settings, configure them in `diagnostics.otel` (see Option 1 above).
+> **Note:** Custom plugin settings live under `plugins.entries.otel-observability.config`. OpenClaw's built-in diagnostics exporter uses a separate `diagnostics.otel` block; do not mix the two config surfaces.
 
 ### Step 4: Clear Cache and Restart
 

--- a/index.ts
+++ b/index.ts
@@ -247,8 +247,6 @@ const otelObservabilityPlugin = {
           unsubscribeDiagnostics();
           unsubscribeDiagnostics = null;
         }
-        // Unbridge the logger BEFORE shutting the pipeline so no late log
-        // call attempts to push into a draining exporter.
         if (restoreLogger) {
           restoreLogger();
           restoreLogger = null;
@@ -257,10 +255,18 @@ const otelObservabilityPlugin = {
           await logPipeline.shutdown();
           logPipeline = null;
         }
+        // Flush pending data but do NOT destroy the providers. OC's config
+        // hot-reload calls stop() → register() in sequence; a destructive
+        // shutdown() here kills the TracerProvider's exporter, and the new
+        // register() cycle's hooks still hold closures over the old runtime
+        // whose tracer routes through the (now dead) global provider.
+        // Flush is non-destructive: pending spans/metrics drain to the
+        // collector, but the providers stay usable for the existing hooks.
+        // True shutdown happens on process exit via the OTel SDK's
+        // registered signal handlers.
         if (telemetry) {
-          await telemetry.shutdown();
-          telemetry = null;
-          logger.info("[otel] Telemetry shut down");
+          await telemetry.flush();
+          logger.info("[otel] Telemetry flushed (providers preserved for hot-reload)");
         }
       },
     });

--- a/index.ts
+++ b/index.ts
@@ -36,6 +36,9 @@ import { registerHooks } from "./src/hooks.js";
 import { registerDiagnosticsListener, hasDiagnosticsSupport } from "./src/diagnostics.js";
 import { initLogPipeline, bridgeGatewayLogger, type LogPipelineRuntime } from "./src/logs.js";
 
+let gatewayStopFinalizer: (() => Promise<void>) | null = null;
+let gatewayStopFinalizationStarted = false;
+
 // ── Public re-exports ───────────────────────────────────────────────
 // W3C trace context propagation helpers. Available without the plugin
 // register lifecycle so user code (custom RPC, message queues,
@@ -71,6 +74,15 @@ const otelObservabilityPlugin = {
     let unsubscribeDiagnostics: (() => void) | null = null;
     let stopHooks: (() => void) | null = null;
 
+    const shutdownTelemetry = async () => {
+      if (!telemetry) return;
+      await telemetry.shutdown();
+      telemetry = null;
+      logger.info("[otel] Telemetry shut down on gateway_stop");
+    };
+    gatewayStopFinalizer = shutdownTelemetry;
+    gatewayStopFinalizationStarted = false;
+
     // ── Telemetry + hooks (init at register() time) ─────────────────
     // Telemetry, the log pipeline, and hooks ALL run during register()
     // so they work in every OpenClaw context, not just the gateway:
@@ -99,6 +111,14 @@ const otelObservabilityPlugin = {
       }
 
       stopHooks = registerHooks(api, () => telemetry, config);
+      // `api.on` does not expose an unsubscribe handle. If a host retains
+      // old hook registrations across hot reloads, every registered wrapper
+      // shares this module-level guard and dispatches only the latest finalizer.
+      api.on?.("gateway_stop", async () => {
+        if (gatewayStopFinalizationStarted) return;
+        gatewayStopFinalizationStarted = true;
+        await gatewayStopFinalizer?.();
+      });
       logger.info("[otel] Telemetry + hooks initialized at register() (runner-compatible)");
     } catch (err) {
       logger.error(`[otel] Failed to initialize telemetry at register() time: ${String(err)}`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,8 +41,17 @@
       "label": "Metrics Export Interval (ms)",
       "advanced": true
     },
+    "sampleRate": {
+      "label": "Trace Sampling Rate",
+      "help": "Optional head-based sampling rate from 0.0 to 1.0",
+      "advanced": true
+    },
     "resourceAttributes": {
       "label": "Extra Resource Attributes",
+      "advanced": true
+    },
+    "logConfig": {
+      "label": "Log Pipeline Filters",
       "advanced": true
     }
   },
@@ -124,12 +133,23 @@
         "minimum": 1000,
         "description": "Metrics export interval in milliseconds"
       },
+      "sampleRate": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Optional head-based trace sampling rate from 0.0 to 1.0"
+      },
       "resourceAttributes": {
         "type": "object",
         "additionalProperties": {
           "type": "string"
         },
         "description": "Additional OTel resource attributes"
+      },
+      "logConfig": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Optional log pipeline filtering configuration"
       }
     }
   }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,6 +4,9 @@
   "description": "Traces, metrics, and logs for OpenClaw using OpenLLMetry and OpenTelemetry",
   "version": "0.6.0",
   "minOpenClawVersion": "2026.4.21",
+  "contracts": {
+    "tools": ["otel_status"]
+  },
   "uiHints": {
     "endpoint": {
       "label": "OTLP Endpoint",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -27,9 +27,31 @@ import {
   TOKEN_TYPE_CACHE_CREATION,
 } from "./semconv.js";
 
+type DiagnosticEventSource = (listener: (evt: any) => void) => () => void;
+
 // Import from OpenClaw plugin SDK (loaded lazily)
-let onDiagnosticEvent: ((listener: (evt: any) => void) => () => void) | null = null;
+let onDiagnosticEvent: DiagnosticEventSource | null = null;
 let sdkLoadAttempted = false;
+
+function asDiagnosticEventSource(candidate: unknown): DiagnosticEventSource | null {
+  if (typeof candidate !== "function") return null;
+  try {
+    const unsubscribe = candidate(() => {});
+    if (typeof unsubscribe !== "function") return null;
+    unsubscribe();
+    return candidate as DiagnosticEventSource;
+  } catch {
+    return null;
+  }
+}
+
+function findDiagnosticEventSource(candidates: unknown[]): DiagnosticEventSource | null {
+  for (const candidate of candidates) {
+    const eventSource = asDiagnosticEventSource(candidate);
+    if (eventSource) return eventSource;
+  }
+  return null;
+}
 
 async function loadSdk(): Promise<void> {
   if (sdkLoadAttempted) return;
@@ -38,29 +60,61 @@ async function loadSdk(): Promise<void> {
     // Dynamic import to avoid build issues if SDK not available
     // @ts-ignore - openclaw/plugin-sdk types not available at build time
     const sdk = await import("openclaw/plugin-sdk") as any;
-    onDiagnosticEvent = sdk.onDiagnosticEvent;
+    onDiagnosticEvent = asDiagnosticEventSource(sdk.onDiagnosticEvent);
   } catch {
     // SDK not available — will use fallback token extraction
   }
 }
 
 // Direct access to internal diagnostic events (preferred - bypasses SDK wrapper)
-let onInternalDiagnosticEvent: ((listener: (evt: any) => void) => () => void) | null = null;
+let onInternalDiagnosticEvent: DiagnosticEventSource | null = null;
 let internalLoadAttempted = false;
 
 async function loadInternalDiagnostics(): Promise<void> {
   if (internalLoadAttempted) return;
   internalLoadAttempted = true;
   try {
+    // Prefer the stable package export when present. Older OpenClaw builds did
+    // not expose this path, so keep the packaged-chunk scan below as fallback.
+    // @ts-ignore - openclaw/plugin-sdk types not available at build time
+    const runtime = await import("openclaw/plugin-sdk/diagnostic-runtime") as any;
+    onInternalDiagnosticEvent = asDiagnosticEventSource(runtime.onInternalDiagnosticEvent);
+    if (onInternalDiagnosticEvent) return;
+  } catch {
+    // Stable diagnostic-runtime export not available.
+  }
+
+  try {
     const fs = await import("fs");
     const path = await import("path");
-    const ocDist = path.dirname(process.argv[1]);
-    const chunk = fs.readdirSync(ocDist).find((f: string) => f.startsWith("diagnostic-events-") && f.endsWith(".js"));
-    if (!chunk) return;
-    const diag = await import(path.join(ocDist, chunk)) as any;
-    onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent
-      ?? Object.values(diag).find((v: any) => typeof v === "function" && v.name === "onInternalDiagnosticEvent") as any
-      ?? null;
+    const { pathToFileURL } = await import("url");
+    const argvEntry = process.argv[1];
+    if (!argvEntry) return;
+    const launcherDir = path.dirname(fs.realpathSync(path.resolve(argvEntry)));
+    const candidateDirs = Array.from(new Set([
+      launcherDir,
+      path.join(launcherDir, "dist"),
+    ]));
+
+    for (const candidateDir of candidateDirs) {
+      let chunks: string[];
+      try {
+        chunks = fs.readdirSync(candidateDir)
+          .filter((f: string) => f.startsWith("diagnostic-events-") && f.endsWith(".js"))
+          .sort();
+      } catch {
+        continue;
+      }
+
+      for (const chunk of chunks) {
+        const diag = await import(pathToFileURL(path.join(candidateDir, chunk)).href) as any;
+        onInternalDiagnosticEvent =
+          asDiagnosticEventSource(diag.onInternalDiagnosticEvent)
+          ?? asDiagnosticEventSource(diag.d)
+          ?? findDiagnosticEventSource(Object.values(diag));
+        if (onInternalDiagnosticEvent) return;
+      }
+    }
   } catch {
     // Internal module not available
   }
@@ -382,7 +436,7 @@ export function enrichSpanWithUsage(span: Span, data: PendingUsageData): void {
  * Note: Only accurate after registerDiagnosticsListener() has been called.
  */
 export function hasDiagnosticsSupport(): boolean {
-  return onDiagnosticEvent !== null;
+  return typeof onDiagnosticEvent === "function" || typeof onInternalDiagnosticEvent === "function";
 }
 
 /**
@@ -390,5 +444,6 @@ export function hasDiagnosticsSupport(): boolean {
  */
 export async function checkDiagnosticsSupport(): Promise<boolean> {
   await loadSdk();
-  return onDiagnosticEvent !== null;
+  await loadInternalDiagnostics();
+  return hasDiagnosticsSupport();
 }

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -52,10 +52,15 @@ async function loadInternalDiagnostics(): Promise<void> {
   if (internalLoadAttempted) return;
   internalLoadAttempted = true;
   try {
-    // Try to load from the internal module directly (use absolute path)
-    // @ts-ignore
-    const diag = await import("/home/hrexed/.npm-global/lib/node_modules/openclaw/dist/diagnostic-events-CjwOn-Qj.js") as any;
-    onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent || diag.o;
+    const fs = await import("fs");
+    const path = await import("path");
+    const ocDist = path.dirname(process.argv[1]);
+    const chunk = fs.readdirSync(ocDist).find((f: string) => f.startsWith("diagnostic-events-") && f.endsWith(".js"));
+    if (!chunk) return;
+    const diag = await import(path.join(ocDist, chunk)) as any;
+    onInternalDiagnosticEvent = diag.onInternalDiagnosticEvent
+      ?? Object.values(diag).find((v: any) => typeof v === "function" && v.name === "onInternalDiagnosticEvent") as any
+      ?? null;
   } catch {
     // Internal module not available
   }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -263,6 +263,33 @@ export interface OtelGauges {
 let initializedRuntime: TelemetryRuntime | null = null;
 let tracerProviderRef: NodeTracerProvider | null = null;
 
+type FlushableProvider = {
+  forceFlush: () => Promise<void>;
+};
+
+function getFlushableGlobalTracerProvider(): FlushableProvider | undefined {
+  try {
+    const provider = trace.getTracerProvider() as unknown as {
+      forceFlush?: () => Promise<void>;
+      getDelegate?: () => unknown;
+    };
+    const delegate =
+      typeof provider.getDelegate === "function"
+        ? provider.getDelegate()
+        : provider;
+    if (
+      delegate &&
+      typeof (delegate as { forceFlush?: unknown }).forceFlush === "function"
+    ) {
+      return delegate as FlushableProvider;
+    }
+  } catch {
+    // If the global provider cannot be inspected, fall back to the plugin
+    // provider below (if any). Flush is best-effort and must not break OC.
+  }
+  return undefined;
+}
+
 export function initTelemetry(config: OtelObservabilityConfig, logger: any): TelemetryRuntime {
   // Idempotent: if we already initialized, reuse the existing runtime.
   // This prevents tracerProvider.register() from being called multiple
@@ -303,6 +330,7 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
   // ── Tracing ─────────────────────────────────────────────────────
 
   let tracerProvider: NodeTracerProvider | undefined;
+  let preloadedTracerProvider: FlushableProvider | undefined;
 
   if (config.traces) {
     if (hasPreloadedOtelSdk()) {
@@ -311,6 +339,7 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       // the preload's, dropping GenAI auto-instrumentation spans. Reuse the
       // existing global provider — trace.getTracer() below will return a
       // tracer backed by it.
+      preloadedTracerProvider = getFlushableGlobalTracerProvider();
       logger.info("[otel] Reusing preloaded OpenTelemetry SDK (skipping plugin TracerProvider registration)");
     } else {
       if (readPreloadHint()) {
@@ -677,6 +706,9 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       // Never let metric heartbeat errors affect the gateway
     }
   }, config.metricsIntervalMs || 30_000); // Match the export interval
+  if (typeof (metricHeartbeatInterval as { unref?: () => void }).unref === "function") {
+    (metricHeartbeatInterval as { unref: () => void }).unref();
+  }
 
   // ── Flush (non-destructive) ──────────────────────────────────────
   // Drains pending spans and metrics to the collector without destroying
@@ -688,32 +720,71 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
 
   const FLUSH_TIMEOUT_MS = 3_000;
 
-  const flush = async () => {
+  const flushWithTimeout = async (label: string, fn: () => Promise<void>) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
-      if (tracerProvider) await tracerProvider.forceFlush({ timeoutMillis: FLUSH_TIMEOUT_MS });
-      if (meterProvider) await meterProvider.forceFlush({ timeoutMillis: FLUSH_TIMEOUT_MS });
+      await Promise.race([
+        fn(),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error(`${label} flush timed out after ${FLUSH_TIMEOUT_MS}ms`)),
+            FLUSH_TIMEOUT_MS,
+          );
+        }),
+      ]);
     } catch (err) {
-      logger.warn?.(`[otel] Flush warning: ${err instanceof Error ? err.message : String(err)}`);
+      logger.warn?.(
+        `[otel] ${label} flush warning: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
+  };
+
+  const flush = async () => {
+    const flushableTracerProvider =
+      tracerProvider ?? preloadedTracerProvider;
+    await Promise.all([
+      flushableTracerProvider
+        ? flushWithTimeout("trace", () => flushableTracerProvider.forceFlush())
+        : Promise.resolve(),
+      meterProvider
+        ? flushWithTimeout("metric", () =>
+            meterProvider.forceFlush({ timeoutMillis: FLUSH_TIMEOUT_MS }),
+          )
+        : Promise.resolve(),
+    ]);
   };
 
   (globalThis as any)[Symbol.for("openclaw.otel.preExit")] = flush;
 
   // ── Shutdown (destructive — process exit only) ─────────────────
 
+  let shutdownPromise: Promise<void> | null = null;
+
   const shutdown = async () => {
-    logger.info("[otel] Shutting down telemetry...");
-    clearInterval(metricHeartbeatInterval);
-    (globalThis as any)[Symbol.for("openclaw.otel.preExit")] = undefined;
-    try {
-      if (tracerProvider) await tracerProvider.shutdown();
-      if (meterProvider) await meterProvider.shutdown();
-    } catch (err) {
-      logger.error(`[otel] Shutdown error: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      initializedRuntime = null;
-      tracerProviderRef = null;
-    }
+    if (shutdownPromise) return shutdownPromise;
+    shutdownPromise = (async () => {
+      logger.info("[otel] Shutting down telemetry...");
+      clearInterval(metricHeartbeatInterval);
+      (globalThis as any)[Symbol.for("openclaw.otel.preExit")] = undefined;
+      try {
+        const results = await Promise.allSettled([
+          tracerProvider ? tracerProvider.shutdown() : Promise.resolve(),
+          meterProvider ? meterProvider.shutdown() : Promise.resolve(),
+        ]);
+        for (const result of results) {
+          if (result.status === "rejected") {
+            const err = result.reason;
+            logger.error(`[otel] Shutdown error: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+      } finally {
+        initializedRuntime = null;
+        tracerProviderRef = null;
+      }
+    })();
+    return shutdownPromise;
   };
 
   const runtime: TelemetryRuntime = { tracer, meter, counters, histograms, gauges, shutdown, flush };

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -128,6 +128,9 @@ export interface TelemetryRuntime {
   histograms: OtelHistograms;
   gauges: OtelGauges;
   shutdown: () => Promise<void>;
+  /** Flush pending spans/metrics without destroying the providers. Safe to
+   *  call on hot-reload — providers remain usable after flush returns. */
+  flush: () => Promise<void>;
 }
 
 export interface OtelCounters {
@@ -675,24 +678,45 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
     }
   }, config.metricsIntervalMs || 30_000); // Match the export interval
 
-  // ── Shutdown ────────────────────────────────────────────────────
+  // ── Flush (non-destructive) ──────────────────────────────────────
+  // Drains pending spans and metrics to the collector without destroying
+  // the providers. Safe to call on config hot-reload — the providers
+  // remain usable after flush returns. Also exposed via a well-known
+  // global Symbol so the CLI exit handler can flush before process.exit()
+  // in --local mode (where BatchSpanProcessor would otherwise lose its
+  // queue).
+
+  const FLUSH_TIMEOUT_MS = 3_000;
+
+  const flush = async () => {
+    try {
+      if (tracerProvider) await tracerProvider.forceFlush({ timeoutMillis: FLUSH_TIMEOUT_MS });
+      if (meterProvider) await meterProvider.forceFlush({ timeoutMillis: FLUSH_TIMEOUT_MS });
+    } catch (err) {
+      logger.warn?.(`[otel] Flush warning: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  (globalThis as any)[Symbol.for("openclaw.otel.preExit")] = flush;
+
+  // ── Shutdown (destructive — process exit only) ─────────────────
 
   const shutdown = async () => {
     logger.info("[otel] Shutting down telemetry...");
     clearInterval(metricHeartbeatInterval);
+    (globalThis as any)[Symbol.for("openclaw.otel.preExit")] = undefined;
     try {
       if (tracerProvider) await tracerProvider.shutdown();
       if (meterProvider) await meterProvider.shutdown();
     } catch (err) {
       logger.error(`[otel] Shutdown error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      // Clear module-level refs so a legitimate restart can re-register.
       initializedRuntime = null;
       tracerProviderRef = null;
     }
   };
 
-  const runtime: TelemetryRuntime = { tracer, meter, counters, histograms, gauges, shutdown };
+  const runtime: TelemetryRuntime = { tracer, meter, counters, histograms, gauges, shutdown, flush };
   initializedRuntime = runtime;
   return runtime;
 }

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const tempDirs: string[] = [];
+let savedArgv1: string | undefined;
+
+function createPackagedOpenClaw(chunkSource: string): {
+  root: string;
+  launcherPath: string;
+  chunkPath: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "otel-diagnostics-test-"));
+  tempDirs.push(root);
+  const dist = path.join(root, "dist");
+  fs.mkdirSync(dist);
+  const launcherPath = path.join(root, "openclaw.mjs");
+  fs.writeFileSync(launcherPath, "export {};\n");
+  const chunkPath = path.join(dist, "diagnostic-events-test.js");
+  fs.writeFileSync(chunkPath, chunkSource);
+  return { root, launcherPath, chunkPath };
+}
+
+function writeDiagnosticChunk(root: string, name: string, chunkSource: string): string {
+  const chunkPath = path.join(root, "dist", name);
+  fs.writeFileSync(chunkPath, chunkSource);
+  return chunkPath;
+}
+
+function fakeTelemetry() {
+  return {
+    counters: {},
+    histograms: {},
+    meter: {},
+  };
+}
+
+describe("internal diagnostics loader", () => {
+  afterEach(() => {
+    if (savedArgv1 === undefined) {
+      process.argv.splice(1, 1);
+    } else {
+      process.argv[1] = savedArgv1;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("loads diagnostic-events chunks from packaged launcher sibling dist", async () => {
+    savedArgv1 = process.argv[1];
+    const { launcherPath, chunkPath } = createPackagedOpenClaw(`
+      export const state = { listener: null, unsubscribed: false };
+      export function onInternalDiagnosticEvent(listener) {
+        state.listener = listener;
+        return () => { state.unsubscribed = true; };
+      }
+    `);
+    process.argv[1] = launcherPath;
+
+    const diagnostics = await import("../src/diagnostics.js");
+    const unsubscribe = await diagnostics.registerDiagnosticsListener(
+      fakeTelemetry() as any,
+      { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    );
+    const fixture = await import(pathToFileURL(chunkPath).href);
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+    expect(typeof fixture.state.listener).toBe("function");
+    unsubscribe();
+    expect(fixture.state.unsubscribed).toBe(true);
+  });
+
+  it("supports the minified internal listener export fallback", async () => {
+    savedArgv1 = process.argv[1];
+    const { launcherPath, chunkPath } = createPackagedOpenClaw(`
+      export const state = { listener: null };
+      export function d(listener) {
+        state.listener = listener;
+        return () => {};
+      }
+    `);
+    process.argv[1] = launcherPath;
+
+    const diagnostics = await import("../src/diagnostics.js");
+    await diagnostics.registerDiagnosticsListener(
+      fakeTelemetry() as any,
+      { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    );
+    const fixture = await import(pathToFileURL(chunkPath).href);
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+    expect(typeof fixture.state.listener).toBe("function");
+  });
+
+  it("does not accept unrelated minified emitter exports as listener support", async () => {
+    savedArgv1 = process.argv[1];
+    const { launcherPath } = createPackagedOpenClaw(`
+      export function o() {
+        return undefined;
+      }
+    `);
+    process.argv[1] = launcherPath;
+
+    const diagnostics = await import("../src/diagnostics.js");
+    await diagnostics.registerDiagnosticsListener(
+      fakeTelemetry() as any,
+      { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    );
+
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(false);
+  });
+
+  it("tries later diagnostic-events chunks when the first one lacks a listener", async () => {
+    savedArgv1 = process.argv[1];
+    const { root, launcherPath, chunkPath } = createPackagedOpenClaw(`
+      export function unrelated() {
+        return undefined;
+      }
+    `);
+    const secondChunkPath = writeDiagnosticChunk(root, "diagnostic-events-z-listener.js", `
+      export const state = { listener: null };
+      export function d(listener) {
+        state.listener = listener;
+        return () => {};
+      }
+    `);
+    process.argv[1] = launcherPath;
+
+    const diagnostics = await import("../src/diagnostics.js");
+    await diagnostics.registerDiagnosticsListener(
+      fakeTelemetry() as any,
+      { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    );
+    const firstFixture = await import(pathToFileURL(chunkPath).href);
+    const secondFixture = await import(pathToFileURL(secondChunkPath).href);
+
+    expect(firstFixture.unrelated()).toBeUndefined();
+    expect(diagnostics.hasDiagnosticsSupport()).toBe(true);
+    expect(typeof secondFixture.state.listener).toBe("function");
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -151,6 +151,7 @@ function createTelemetry(): { telemetry: TelemetryRuntime; spans: Array<Span & S
       activeSessions: noopUpDownCounter(),
     } as unknown as TelemetryRuntime["gauges"],
     shutdown: async () => {},
+    flush: async () => {},
   };
   return { telemetry, spans };
 }
@@ -1092,7 +1093,9 @@ describe("before_tool_call / after_tool_call hooks (ISI-927)", () => {
       { sessionKey: "s6", agentId: "a1" },
     );
 
-    expect(spans.length).toBe(2); // agent.turn + execute_tool
+    const toolSpanBeforePersist = spans.find((s) => s.spanName === "execute_tool Read");
+    expect(toolSpanBeforePersist).toBeDefined();
+    const spanCountBeforePersist = spans.length;
 
     toolPersist(
       {
@@ -1106,11 +1109,10 @@ describe("before_tool_call / after_tool_call hooks (ISI-927)", () => {
       { sessionKey: "s6", agentId: "a1" },
     );
 
-    expect(spans.length).toBe(2); // No new span created
+    expect(spans.length).toBe(spanCountBeforePersist); // No new span created
+    expect(spans.find((s) => s.spanName === "execute_tool Read")).toBe(toolSpanBeforePersist);
 
-    const toolSpan = spans.find((s) => s.spanName === "execute_tool Read");
-    expect(toolSpan).toBeDefined();
-    expect(toolSpan!.attrs["openclaw.tool.result_chars"]).toBe("127.0.0.1 localhost".length);
+    expect(toolSpanBeforePersist!.attrs["openclaw.tool.result_chars"]).toBe("127.0.0.1 localhost".length);
 
     stopHooks();
   });
@@ -2792,4 +2794,3 @@ describe("ISI-1004: diagnostics.enrichSpanWithUsage legacy removal (schema 1.3.0
     expect(spy.attrs["gen_ai.usage.total_tokens"]).toBeUndefined();
   });
 });
-

--- a/tests/plugin-lifecycle.test.ts
+++ b/tests/plugin-lifecycle.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("plugin service lifecycle", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("stop flushes telemetry without destructively shutting providers down", async () => {
+    vi.resetModules();
+
+    const flush = vi.fn().mockResolvedValue(undefined);
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    const stopHooks = vi.fn();
+    const unsubscribeDiagnostics = vi.fn();
+
+    vi.doMock("../src/telemetry.js", () => ({
+      initTelemetry: vi.fn(() => ({
+        tracer: {},
+        meter: {},
+        counters: {},
+        histograms: {},
+        gauges: {},
+        flush,
+        shutdown,
+      })),
+      hasPreloadedOtelSdk: vi.fn(() => false),
+    }));
+    vi.doMock("../src/openllmetry.js", () => ({
+      initOpenLLMetry: vi.fn(),
+    }));
+    vi.doMock("../src/hooks.js", () => ({
+      registerHooks: vi.fn(() => stopHooks),
+    }));
+    vi.doMock("../src/diagnostics.js", () => ({
+      registerDiagnosticsListener: vi.fn().mockResolvedValue(unsubscribeDiagnostics),
+      hasDiagnosticsSupport: vi.fn(() => true),
+    }));
+    vi.doMock("../src/logs.js", () => ({
+      initLogPipeline: vi.fn(() => null),
+      bridgeGatewayLogger: vi.fn(),
+    }));
+
+    const services: Array<{ stop?: () => Promise<void> }> = [];
+    const api = {
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      pluginConfig: {
+        endpoint: "http://127.0.0.1:14318",
+        traces: true,
+        metrics: true,
+        logs: false,
+      },
+      registerGatewayMethod: vi.fn(),
+      registerCli: vi.fn(),
+      registerService: vi.fn((service) => services.push(service)),
+      registerTool: vi.fn(),
+      on: vi.fn(),
+    };
+
+    const plugin = (await import("../index.js")).default;
+    plugin.register(api);
+    await Promise.resolve();
+
+    expect(services).toHaveLength(1);
+    await services[0]!.stop?.();
+
+    expect(stopHooks).toHaveBeenCalledTimes(1);
+    expect(unsubscribeDiagnostics).toHaveBeenCalledTimes(1);
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(shutdown).not.toHaveBeenCalled();
+    expect(api.logger.info).toHaveBeenCalledWith(
+      "[otel] Telemetry flushed (providers preserved for hot-reload)",
+    );
+  });
+
+  it("gateway_stop destructively shuts telemetry down once", async () => {
+    vi.resetModules();
+
+    const flush = vi.fn().mockResolvedValue(undefined);
+    const shutdown = vi.fn().mockResolvedValue(undefined);
+    const stopHooks = vi.fn();
+    const gatewayHooks = new Map<string, () => Promise<void>>();
+
+    vi.doMock("../src/telemetry.js", () => ({
+      initTelemetry: vi.fn(() => ({
+        tracer: {},
+        meter: {},
+        counters: {},
+        histograms: {},
+        gauges: {},
+        flush,
+        shutdown,
+      })),
+      hasPreloadedOtelSdk: vi.fn(() => false),
+    }));
+    vi.doMock("../src/openllmetry.js", () => ({
+      initOpenLLMetry: vi.fn(),
+    }));
+    vi.doMock("../src/hooks.js", () => ({
+      registerHooks: vi.fn(() => stopHooks),
+    }));
+    vi.doMock("../src/diagnostics.js", () => ({
+      registerDiagnosticsListener: vi.fn().mockResolvedValue(() => {}),
+      hasDiagnosticsSupport: vi.fn(() => true),
+    }));
+    vi.doMock("../src/logs.js", () => ({
+      initLogPipeline: vi.fn(() => null),
+      bridgeGatewayLogger: vi.fn(),
+    }));
+
+    const services: Array<{ stop?: () => Promise<void> }> = [];
+    const api = {
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      pluginConfig: {
+        endpoint: "http://127.0.0.1:14318",
+        traces: true,
+        metrics: true,
+        logs: false,
+      },
+      registerGatewayMethod: vi.fn(),
+      registerCli: vi.fn(),
+      registerService: vi.fn((service) => services.push(service)),
+      registerTool: vi.fn(),
+      on: vi.fn((hookName: string, handler: () => Promise<void>) => {
+        gatewayHooks.set(hookName, handler);
+      }),
+    };
+
+    const plugin = (await import("../index.js")).default;
+    plugin.register(api);
+    await Promise.resolve();
+
+    expect(api.on).toHaveBeenCalledWith("gateway_stop", expect.any(Function));
+    await gatewayHooks.get("gateway_stop")!();
+    await gatewayHooks.get("gateway_stop")!();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(api.logger.info).toHaveBeenCalledWith(
+      "[otel] Telemetry shut down on gateway_stop",
+    );
+
+    await services[0]!.stop?.();
+    expect(flush).not.toHaveBeenCalled();
+  });
+
+  it("accumulated gateway_stop handlers across reload finalize only once", async () => {
+    vi.resetModules();
+
+    const firstShutdown = vi.fn().mockResolvedValue(undefined);
+    const secondShutdown = vi.fn().mockResolvedValue(undefined);
+    const stopHooks = vi.fn();
+    const gatewayHooks: Array<() => Promise<void>> = [];
+
+    vi.doMock("../src/telemetry.js", () => ({
+      initTelemetry: vi.fn()
+        .mockReturnValueOnce({
+          tracer: {},
+          meter: {},
+          counters: {},
+          histograms: {},
+          gauges: {},
+          flush: vi.fn().mockResolvedValue(undefined),
+          shutdown: firstShutdown,
+        })
+        .mockReturnValueOnce({
+          tracer: {},
+          meter: {},
+          counters: {},
+          histograms: {},
+          gauges: {},
+          flush: vi.fn().mockResolvedValue(undefined),
+          shutdown: secondShutdown,
+        }),
+      hasPreloadedOtelSdk: vi.fn(() => false),
+    }));
+    vi.doMock("../src/openllmetry.js", () => ({
+      initOpenLLMetry: vi.fn(),
+    }));
+    vi.doMock("../src/hooks.js", () => ({
+      registerHooks: vi.fn(() => stopHooks),
+    }));
+    vi.doMock("../src/diagnostics.js", () => ({
+      registerDiagnosticsListener: vi.fn().mockResolvedValue(() => {}),
+      hasDiagnosticsSupport: vi.fn(() => true),
+    }));
+    vi.doMock("../src/logs.js", () => ({
+      initLogPipeline: vi.fn(() => null),
+      bridgeGatewayLogger: vi.fn(),
+    }));
+
+    const services: Array<{ stop?: () => Promise<void> }> = [];
+    const api = {
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      pluginConfig: {
+        endpoint: "http://127.0.0.1:14318",
+        traces: true,
+        metrics: true,
+        logs: false,
+      },
+      registerGatewayMethod: vi.fn(),
+      registerCli: vi.fn(),
+      registerService: vi.fn((service) => services.push(service)),
+      registerTool: vi.fn(),
+      on: vi.fn((_hookName: string, handler: () => Promise<void>) => {
+        gatewayHooks.push(handler);
+      }),
+    };
+
+    const plugin = (await import("../index.js")).default;
+    plugin.register(api);
+    await services[0]!.stop?.();
+    plugin.register(api);
+    await Promise.resolve();
+
+    expect(gatewayHooks).toHaveLength(2);
+    await Promise.all(gatewayHooks.map((handler) => handler()));
+
+    expect(firstShutdown).not.toHaveBeenCalled();
+    expect(secondShutdown).toHaveBeenCalledTimes(1);
+    expect(api.logger.info.mock.calls.filter(
+      (call) => call[0] === "[otel] Telemetry shut down on gateway_stop",
+    )).toHaveLength(1);
+  });
+});

--- a/tests/telemetry-lifecycle.test.ts
+++ b/tests/telemetry-lifecycle.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trace, type TracerProvider } from "@opentelemetry/api";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { MeterProvider } from "@opentelemetry/sdk-metrics";
+
+import { CONTENT_POLICY_DISABLED, type OtelObservabilityConfig } from "../src/config.js";
+import { PRELOADED_OTEL_SDK_ENV, initTelemetry, type TelemetryRuntime } from "../src/telemetry.js";
+
+const PRE_EXIT_SYMBOL = Symbol.for("openclaw.otel.preExit");
+
+function baseConfig(
+  overrides: Partial<OtelObservabilityConfig> = {},
+): OtelObservabilityConfig {
+  return {
+    endpoint: "http://127.0.0.1:14318",
+    protocol: "http",
+    serviceName: "telemetry-lifecycle-test",
+    headers: {},
+    traces: false,
+    metrics: false,
+    logs: false,
+    captureContent: { ...CONTENT_POLICY_DISABLED },
+    metricsIntervalMs: 30_000,
+    resourceAttributes: {},
+    ...overrides,
+  };
+}
+
+function makeLoggerSpy() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe("telemetry runtime lifecycle", () => {
+  const runtimes: TelemetryRuntime[] = [];
+  let savedPreloadEnv: string | undefined;
+
+  function track(runtime: TelemetryRuntime): TelemetryRuntime {
+    runtimes.push(runtime);
+    return runtime;
+  }
+
+  beforeEach(() => {
+    savedPreloadEnv = process.env[PRELOADED_OTEL_SDK_ENV];
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    for (const runtime of runtimes.splice(0)) {
+      await runtime.shutdown().catch(() => {});
+    }
+    if (savedPreloadEnv === undefined) {
+      delete process.env[PRELOADED_OTEL_SDK_ENV];
+    } else {
+      process.env[PRELOADED_OTEL_SDK_ENV] = savedPreloadEnv;
+    }
+    delete (globalThis as Record<symbol, unknown>)[PRE_EXIT_SYMBOL];
+    vi.restoreAllMocks();
+  });
+
+  it("reuses the initialized runtime across stop/register hot reload", async () => {
+    const logger = makeLoggerSpy();
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    const first = track(initTelemetry(baseConfig(), logger));
+    const second = initTelemetry(
+      baseConfig({ serviceName: "changed-during-hot-reload" }),
+      logger,
+    );
+
+    expect(second).toBe(first);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect((setIntervalSpy.mock.results[0]?.value as { hasRef?: () => boolean }).hasRef?.()).toBe(false);
+    expect(logger.info).toHaveBeenCalledWith(
+      "[otel] Reusing existing telemetry runtime (skipping double registration)",
+    );
+  });
+
+  it("publishes a preExit flush function and shutdown clears it for a real restart", async () => {
+    const logger = makeLoggerSpy();
+    const first = track(initTelemetry(baseConfig(), logger));
+
+    expect((globalThis as Record<symbol, unknown>)[PRE_EXIT_SYMBOL]).toBe(first.flush);
+    await first.shutdown();
+    expect((globalThis as Record<symbol, unknown>)[PRE_EXIT_SYMBOL]).toBeUndefined();
+
+    const second = track(initTelemetry(baseConfig({ serviceName: "after-shutdown" }), logger));
+    expect(second).not.toBe(first);
+    expect((globalThis as Record<symbol, unknown>)[PRE_EXIT_SYMBOL]).toBe(second.flush);
+  });
+
+  it("flushes trace and metric providers independently", async () => {
+    const logger = makeLoggerSpy();
+    const traceFlush = vi
+      .spyOn(NodeTracerProvider.prototype, "forceFlush")
+      .mockRejectedValueOnce(new Error("trace exporter stalled"));
+    const metricFlush = vi
+      .spyOn(MeterProvider.prototype, "forceFlush")
+      .mockResolvedValueOnce();
+
+    const runtime = track(initTelemetry(baseConfig({ traces: true, metrics: true }), logger));
+    await runtime.flush();
+
+    expect(traceFlush).toHaveBeenCalledWith();
+    expect(metricFlush).toHaveBeenCalledWith({ timeoutMillis: 3_000 });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("trace flush warning: trace exporter stalled"),
+    );
+  });
+
+  it("times out stalled provider flushes", async () => {
+    vi.useFakeTimers();
+    const logger = makeLoggerSpy();
+    vi.spyOn(NodeTracerProvider.prototype, "forceFlush").mockImplementationOnce(
+      () => new Promise<void>(() => {}),
+    );
+    const metricFlush = vi
+      .spyOn(MeterProvider.prototype, "forceFlush")
+      .mockResolvedValueOnce();
+
+    const runtime = track(initTelemetry(baseConfig({ traces: true, metrics: true }), logger));
+    const flushPromise = runtime.flush();
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await flushPromise;
+
+    expect(metricFlush).toHaveBeenCalledWith({ timeoutMillis: 3_000 });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("trace flush warning: trace flush timed out after 3000ms"),
+    );
+  });
+
+  it("flushes a preloaded global tracer provider when the plugin did not create one", async () => {
+    savedPreloadEnv = process.env[PRELOADED_OTEL_SDK_ENV];
+    process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+
+    const preloadedForceFlush = vi.fn().mockResolvedValue(undefined);
+    const fakeRealProvider = {
+      constructor: { name: "NodeTracerProvider" },
+      forceFlush: preloadedForceFlush,
+      getTracer: () => ({}),
+    };
+    const fakeProxy = {
+      constructor: { name: "ProxyTracerProvider" },
+      getDelegate: () => fakeRealProvider,
+      getTracer: () => ({}),
+    };
+    vi.spyOn(trace, "getTracerProvider").mockReturnValue(
+      fakeProxy as unknown as TracerProvider,
+    );
+
+    const runtime = track(initTelemetry(baseConfig({ traces: true }), makeLoggerSpy()));
+    await runtime.flush();
+
+    expect(preloadedForceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not flush an unrelated global tracer provider when traces are disabled", async () => {
+    process.env[PRELOADED_OTEL_SDK_ENV] = "1";
+
+    const unrelatedForceFlush = vi.fn().mockResolvedValue(undefined);
+    const fakeRealProvider = {
+      constructor: { name: "NodeTracerProvider" },
+      forceFlush: unrelatedForceFlush,
+      getTracer: () => ({}),
+    };
+    vi.spyOn(trace, "getTracerProvider").mockReturnValue(
+      fakeRealProvider as unknown as TracerProvider,
+    );
+
+    const runtime = track(initTelemetry(baseConfig({ traces: false, metrics: false }), makeLoggerSpy()));
+    await runtime.flush();
+
+    expect(unrelatedForceFlush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

OpenClaw config hot-reload calls this plugin's service `stop()` and then registers the plugin again in the same process. A destructive `telemetry.shutdown()` during `stop()` closes the trace/metric providers while existing hook closures can still resolve the reused runtime, so spans created after reload can be silently dropped.

The diagnostic event fallback also depended on a packaged-file shape that does not match current OpenClaw installs, and the public docs/schema disagreed about where this plugin's config lives.

## Change

- Split telemetry lifecycle:
  - `flush()` is non-destructive and used by service `stop()` for hot reload.
  - `shutdown()` is destructive, idempotent, and reserved for `gateway_stop` / explicit final teardown.
- Add a `gateway_stop` finalizer with a shared guard so repeated reload registrations still shut down telemetry only once.
- Force-flush trace and metric providers independently with a 3s outer timeout, and only flush the plugin-owned tracer provider or a preloaded provider captured during init.
- `unref()` the metric heartbeat interval so it cannot pin process exit.
- Make the internal diagnostics loader prefer `openclaw/plugin-sdk/diagnostic-runtime`, then scan the packaged launcher dir plus sibling `dist`, validate listener functions, use the current minified `d` alias, and try every matching chunk.
- Align manifest schema/docs with the actual plugin config surface: `plugins.entries.otel-observability.config`.

## Hot reload contract

`stop()` drains but does not rebuild trace/metric providers. Provider-affecting fields (`endpoint`, `headers`, `protocol`, `serviceName`, `traces`, `metrics`, `sampleRate`, `metricsIntervalMs`, `resourceAttributes`, and preload-backed content capture) still require a gateway restart. `logs`/`logConfig` can be applied by plugin reload because the log pipeline is rebuilt.

## Real behavior proof

Behavior or issue addressed: hot reload now drains telemetry without permanently closing reusable providers; final teardown happens through `gateway_stop`; diagnostic event loading works against the current packaged OpenClaw shapes; docs/schema now match the plugin config contract.

Real environment tested: local PR worktree `/tmp/openclaw-observability-plugin-pr51-base`, Node v26.1.0/npm v11.13.0, branch head `fbfd0a7c40ce7dd4abab5e5318b7a40045aa51e5`.

Exact steps or command run after this patch:

```bash
npm run typecheck
npm test
node -e "JSON.parse(require('fs').readFileSync('openclaw.plugin.json','utf8')); console.log('openclaw.plugin.json ok')"
git diff --cached --check && git diff --check
```

Evidence after fix: typecheck passed; full suite passed (`12` Vitest files, `256` tests, plus `instrumentation/capture-content.test.mjs`); manifest JSON parsed cleanly; whitespace check passed before commit.

Observed result after fix: service `stop()` calls non-destructive `flush()`; `gateway_stop` calls destructive `shutdown()` once across reload registrations; trace and metric flushes run independently with bounded timeout; disabled-traces flush no longer touches unrelated global tracer providers; diagnostics fallback resolves stable SDK/minified/chunked listener exports; schema accepts documented `sampleRate` and `logConfig`.

What was not tested: a running OpenClaw gateway hot-reload against a real OTLP collector was not exercised in this worktree. The lifecycle, diagnostics, and config behavior are covered by focused regression tests plus the full package suite.

## Review gates

Four read-only multi-lane review agents completed and their actionable findings were fixed. Claude review completed after escalation, reported the patch merge-ready, and its low-severity refinements were fixed. Codex review was attempted with a 600s timeout but did not produce a final finding list before timing out, so it is not counted as a completed gate.
