### PR TITLE
docs(install): fix operator version pin + document plugin-manager install (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Install the plugin from npm. This is the path that the [openclaw-operator](https
 npm install @henrikrexed/openclaw-otel-observability
 ```
 
+Or install it directly through OpenClaw's plugin manager (pin the version to the current release):
+
+```bash
+openclaw plugins install --force npm:@henrikrexed/openclaw-otel-observability@0.7.0
+```
+
 Then add it to your `openclaw.json`:
 
 ```json
@@ -207,7 +213,7 @@ kind: OpenClawInstance
 spec:
   plugins:
     - name: "@henrikrexed/openclaw-otel-observability"
-      version: "^0.3.1"
+      version: "^0.7.0"
 ```
 
 Clear the jiti cache and restart the gateway:


### PR DESCRIPTION
## Summary
Fixes the install-documentation half of #57.

- **Operator version pin bug**: the `OpenClawInstance.spec.plugins` example pinned `version: "^0.3.1"`, which resolves `<0.4.0` and cannot install the current **0.7.0** release. Bumped to `^0.7.0`.
- **Documented the plugin-manager coordinate** `openclaw plugins install --force npm:@henrikrexed/openclaw-otel-observability@0.7.0` — the exact command from #57.

## Context — npm publish is a separate, pending step
Ground truth as of this PR:
- `npm view @henrikrexed/openclaw-otel-observability` → **404, not published at any version**.
- `v0.7.0` **is** a real GitHub release (all of README/package.json/openclaw.plugin.json/manifest are 0.7.0 — the 0.6.1-vs-0.7.0 mismatch #57 cited is already resolved).
- **`publish-npm.yml` has never run (0 runs)**: the `v0.7.0` release was authored by `github-actions[bot]` (release-please via `GITHUB_TOKEN`), and `GITHUB_TOKEN`-authored releases do **not** fire the `release: published` event, so the npm-publish job was never triggered.

**To actually resolve #57 the package must be published to npm.** The workflow already has a `workflow_dispatch` fallback — a maintainer with `actions:write` can trigger `publish-npm.yml` on `main` (requires the `NPM_TOKEN` secret to be set). Permanent fix: author release-please releases with a PAT/App token so `release: published` fires downstream.

Resolves the docs portion of #57.