### PR TITLE
feat(ISI-1627): subagent_spawned migration + end-to-end trace propagation

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2120,6 +2120,22 @@ export function registerHooks(
   // resolved fields it carries. The span links to the parent agent turn via
   // the TraceContextStore sub-agent link table so the child session can
   // resolve parent context (ISI-1627 / WS2).
+  //
+  // The span keeps the name "openclaw.subagent.spawning" regardless of which
+  // hook created it — dashboards/alerts key off that stable name; the origin
+  // is distinguished by `code.function.name`. Do not rename per-source.
+  //
+  // Dedup edge case (Copilot review, ISI-1633): when the parent has NO active
+  // session context at spawn time (`sessionCtx == null` — parent spawns before
+  // its own first message), there is no `activeToolSpans` map to stash the span
+  // in, so the sibling hook's dedup check would miss and emit a SECOND span +
+  // double the spawn counter (and the resolved fields from `subagent_spawned`
+  // would be lost). We hold such orphan spawn spans in this closure-scoped map,
+  // keyed by the same `__subagent_<childSessionKey>` stash key, so dedup and
+  // enrichment work identically to the sessionCtx path. Ended by
+  // `subagent_ended`, with a size-bounded backstop against a missing end event.
+  const orphanSubagentSpans = new Map<string, { span: Span; startTime: number }>();
+  const ORPHAN_SPAWN_SPAN_CAP = 256;
 
   /** Apply the `subagent_spawned`-only resolved fields to a spawn span. */
   function applyResolvedSubagentFields(
@@ -2160,7 +2176,10 @@ export function registerHooks(
 
       const sessionCtx = store.getActiveContext(parentSessionKey);
       const stashKey = `__subagent_${childSessionKey}`;
-      const existing = sessionCtx?.activeToolSpans?.get(stashKey);
+      // Look in the parent's activeToolSpans first, then the orphan holding map
+      // (no-sessionCtx path) so the sibling hook dedups + enriches in BOTH cases.
+      const existing =
+        sessionCtx?.activeToolSpans?.get(stashKey) ?? orphanSubagentSpans.get(stashKey);
 
       // Dedupe: the sibling hook already created the span. Enrich it with any
       // resolved fields this event carries (so a `subagent_spawning`-created
@@ -2230,8 +2249,20 @@ export function registerHooks(
         }
         sessionCtx.activeToolSpans.set(stashKey, { span, startTime: Date.now() });
       } else {
-        span.setStatus({ code: SpanStatusCode.OK });
-        span.end();
+        // No parent session context to hang the span's lifecycle on. Hold it in
+        // the closure-scoped orphan map (keyed identically) so the sibling hook
+        // dedups + enriches instead of emitting a second span + double count.
+        // Backstop: if `subagent_ended` never arrives, cap the map and end the
+        // oldest held span so a degenerate runtime can't leak spans unbounded.
+        if (orphanSubagentSpans.size >= ORPHAN_SPAWN_SPAN_CAP) {
+          const oldestKey = orphanSubagentSpans.keys().next().value as string | undefined;
+          if (oldestKey !== undefined) {
+            const stale = orphanSubagentSpans.get(oldestKey);
+            orphanSubagentSpans.delete(oldestKey);
+            stale?.span.end();
+          }
+        }
+        orphanSubagentSpans.set(stashKey, { span, startTime: Date.now() });
       }
 
       logger.debug?.(
@@ -2346,7 +2377,11 @@ export function registerHooks(
 
         const parentSessionCtx = store.getActiveContext(parentSessionKey);
         const subagentKey = `__subagent_${childSessionKey}`;
-        const active = parentSessionCtx?.activeToolSpans?.get(subagentKey);
+        // Spawn span may live in the parent's activeToolSpans (normal path) or
+        // in the orphan holding map (no-sessionCtx spawn — ISI-1633 dedup fix).
+        const active =
+          parentSessionCtx?.activeToolSpans?.get(subagentKey) ??
+          orphanSubagentSpans.get(subagentKey);
 
         if (active) {
           const { span, startTime } = active;
@@ -2395,7 +2430,8 @@ export function registerHooks(
           }
 
           span.end();
-          parentSessionCtx!.activeToolSpans!.delete(subagentKey);
+          parentSessionCtx?.activeToolSpans?.delete(subagentKey);
+          orphanSubagentSpans.delete(subagentKey);
         }
 
         counters.subagentEnded.add(1, {
@@ -2853,9 +2889,22 @@ export function registerHooks(
     if (cleaned > 0) {
       logger.debug?.(`[otel] Cleaned up ${cleaned} stale trace contexts`);
     }
+    // ISI-1633 — sweep orphan spawn spans whose `subagent_ended` never arrived.
+    const now = Date.now();
+    for (const [key, held] of orphanSubagentSpans) {
+      if (now - held.startTime > maxAge) {
+        orphanSubagentSpans.delete(key);
+        held.span.end();
+      }
+    }
   }, 60_000);
 
   return () => {
     clearInterval(cleanupInterval);
+    // Flush any orphan spawn spans still held so shutdown doesn't drop them.
+    for (const [key, held] of orphanSubagentSpans) {
+      orphanSubagentSpans.delete(key);
+      held.span.end();
+    }
   };
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -45,7 +45,7 @@ import {
   type SecurityCounters,
 } from "./security.js";
 import { TraceContextStore } from "./trace-context-store.js";
-import { injectTraceContext, extractTraceContext } from "./propagation.js";
+import { extractTraceContext } from "./propagation.js";
 import {
   GEN_AI_AGENT_ID,
   GEN_AI_AGENT_NAME,
@@ -93,6 +93,7 @@ import {
   OC_SUBAGENT_CHILD_AGENT_ID,
   OC_SUBAGENT_CHILD_AGENT_NAME,
   OC_SUBAGENT_SPAWN_REASON,
+  OC_SUBAGENT_RUN_ID,
   OC_SUBAGENT_DELIVERY_TYPE,
   OC_SUBAGENT_SUCCESS,
   OC_SUBAGENT_DURATION_MS,
@@ -266,6 +267,28 @@ export function registerHooks(
   // TYPED HOOKS — registered via api.on() into registry.typedHooks
   // ═══════════════════════════════════════════════════════════════════
 
+  /**
+   * ISI-1627 / WS2 — resolve the live parent trace context for a session that
+   * was spawned as a subagent in THIS gateway process. Returns `undefined`
+   * for ordinary (non-subagent) sessions.
+   *
+   * Prefers nesting the child request directly under the subagent spawn span
+   * (`__subagent_<childSessionKey>` in the parent's `activeToolSpans`) so the
+   * trace reads parent-turn → spawn → child-request → child-tools. Falls back
+   * to the parent's turn/request context when the spawn span is unavailable.
+   */
+  function resolveSubagentParentContext(childSessionKey: string): Context | undefined {
+    const parentSessionKey = store.getParentSession(childSessionKey);
+    if (!parentSessionKey) return undefined;
+    const base = store.resolveParentContext(childSessionKey)
+      || store.getActiveContext(parentSessionKey)?.rootContext;
+    if (!base) return undefined;
+    const spawn = store
+      .getActiveContext(parentSessionKey)
+      ?.activeToolSpans?.get(`__subagent_${childSessionKey}`);
+    return spawn ? trace.setSpan(base, spawn.span) : base;
+  }
+
   // ── message_received ─────────────────────────────────────────────
   // Creates the ROOT span for the entire request lifecycle.
   // All subsequent spans (agent, tools) become children of this span.
@@ -285,21 +308,57 @@ export function registerHooks(
         const from = event?.from || event?.senderId || "unknown";
         const messageText = event?.text || event?.message || "";
 
-        // Create root span for this request
-        const rootSpan = tracer.startSpan("openclaw.request", {
-          kind: SpanKind.SERVER,
-          attributes: {
-            // openclaw legacy
-            "openclaw.message.channel": channel,
-            "openclaw.session.key": sessionKey,
-            "openclaw.message.direction": "inbound",
-            "openclaw.message.from": from,
-            // GenAI conversation correlation
-            [GEN_AI_CONVERSATION_ID]: sessionKey,
-            // code.*
-            ...codeAttrs("message_received"),
+        // ISI-1627 / WS2 — resolve the parent trace context BEFORE creating
+        // the root span so a spawned subagent's request nests into its
+        // spawner's trace (ONE end-to-end trace.id) rather than starting a
+        // fresh trace root. Two sources, strongest first:
+        //   1. Incoming W3C `traceparent` on the message metadata — external
+        //      / cross-process ingress. Honoured when present.
+        //   2. In-process subagent link — when THIS gateway spawned the
+        //      child, the spawn hook recorded a parent↔child link and the
+        //      parent's spawn-span context is live in this same process. This
+        //      is the reliable path for OpenClaw subagents, which carry no
+        //      `traceparent` across the spawn boundary (the spawn hooks fire a
+        //      fire-and-forget event with no mutable session carrier).
+        const incomingTraceparent = event?.traceContext?.traceparent || event?.metadata?.traceparent;
+        const incomingTracestate = event?.traceContext?.tracestate || event?.metadata?.tracestate;
+
+        let parentContext = context.active();
+        let extractedParent: Context | undefined;
+        if (incomingTraceparent) {
+          const extracted = extractTraceContext({
+            traceparent: incomingTraceparent,
+            tracestate: incomingTracestate,
+          });
+          if (extracted && trace.getSpanContext(extracted)) {
+            extractedParent = extracted;
+            parentContext = extracted;
+          }
+        }
+        if (!extractedParent) {
+          const subagentParent = resolveSubagentParentContext(sessionKey);
+          if (subagentParent) parentContext = subagentParent;
+        }
+
+        // Create root span for this request (parented into the resolved trace).
+        const rootSpan = tracer.startSpan(
+          "openclaw.request",
+          {
+            kind: SpanKind.SERVER,
+            attributes: {
+              // openclaw legacy
+              "openclaw.message.channel": channel,
+              "openclaw.session.key": sessionKey,
+              "openclaw.message.direction": "inbound",
+              "openclaw.message.from": from,
+              // GenAI conversation correlation
+              [GEN_AI_CONVERSATION_ID]: sessionKey,
+              // code.*
+              ...codeAttrs("message_received"),
+            },
           },
-        });
+          parentContext,
+        );
 
         // ═══ SECURITY DETECTION 2: Prompt Injection ═══════════════
         if (messageText && typeof messageText === "string" && messageText.length > 0) {
@@ -326,24 +385,17 @@ export function registerHooks(
           messageText,
         );
 
-        // ISI-1021: Extract W3C trace context from incoming message metadata
-        // (for subagent sessions that were spawned with traceparent injected).
-        const incomingTraceparent = event?.traceContext?.traceparent || event?.metadata?.traceparent;
-        const incomingTracestate = event?.traceContext?.tracestate || event?.metadata?.tracestate;
-        let parentContext = context.active();
-        if (incomingTraceparent) {
-          const extracted = extractTraceContext({
-            traceparent: incomingTraceparent,
-            tracestate: incomingTracestate,
+        // Keep an explicit link to a cross-process `traceparent` parent as a
+        // secondary signal (aids fan-out queries) when one was present. The
+        // re-parenting above is what actually joins the traces; this link is
+        // additive. In-process subagent parents already nest via the resolved
+        // context, so no separate link is emitted for them here.
+        if (extractedParent) {
+          rootSpan.addLink({
+            context: trace.getSpanContext(extractedParent)!,
+            attributes: { "openclaw.link.type": "subagent_child" },
           });
-          if (extracted) {
-            parentContext = extracted;
-            rootSpan.addLink({
-              context: trace.getSpanContext(extracted)!,
-              attributes: { "openclaw.link.type": "subagent_child" },
-            });
-            logger.debug?.(`[otel] Extracted traceparent from subagent session: ${incomingTraceparent}`);
-          }
+          logger.debug?.(`[otel] Extracted traceparent from subagent session: ${incomingTraceparent}`);
         }
 
         // Store the context so child spans can reference it
@@ -2056,105 +2108,162 @@ export function registerHooks(
   // SUB-AGENT ORCHESTRATION HOOKS
   // ═══════════════════════════════════════════════════════════════════
 
-  // ── subagent_spawning ─────────────────────────────────────────────
-  // Fires when a parent agent spawns a sub-agent. Creates a child span
-  // linked to the parent agent's turn span via the TraceContextStore
-  // sub-agent link table. The child session will resolve parent context
-  // for trace correlation.
+  // ── subagent_spawning (deprecated) + subagent_spawned (current) ────
+  // Both hooks describe the SAME spawn event. `subagent_spawned` (ISI-1627 /
+  // WS1) is the current hook and additionally carries the resolved
+  // model/provider/runId; `subagent_spawning` is retained as a deduped
+  // fallback for runtimes in `[2026.4.21, subagent_spawned floor)` and is
+  // removed upstream after 2026-08-30. We emit ONE span per childSessionKey,
+  // deduping on the parent's `__subagent_<childSessionKey>` activeToolSpans
+  // slot: whichever hook fires first creates the span (and the spawn counter);
+  // a later firing of the sibling hook only ENRICHES that span with any
+  // resolved fields it carries. The span links to the parent agent turn via
+  // the TraceContextStore sub-agent link table so the child session can
+  // resolve parent context (ISI-1627 / WS2).
 
+  /** Apply the `subagent_spawned`-only resolved fields to a spawn span. */
+  function applyResolvedSubagentFields(
+    span: Span,
+    model?: string,
+    provider?: string,
+    runId?: string,
+  ): void {
+    if (model) span.setAttribute(GEN_AI_REQUEST_MODEL, model);
+    if (provider) span.setAttribute(GEN_AI_PROVIDER_NAME, provider);
+    if (runId) span.setAttribute(OC_SUBAGENT_RUN_ID, runId);
+  }
+
+  function recordSubagentSpawn(
+    source: "subagent_spawning" | "subagent_spawned",
+    event: any,
+    ctx: any,
+  ): void {
+    try {
+      const tel = getTelemetry();
+      if (!tel) return;
+      const { tracer, counters } = tel;
+
+      const parentSessionKey =
+        ctx?.sessionKey || ctx?.requesterSessionKey || event?.parentSessionKey || "unknown";
+      const childSessionKey = event?.childSessionKey || event?.sessionKey || "unknown";
+      const childAgentId = event?.childAgentId || event?.agentId || "unknown";
+      const childAgentName =
+        event?.childAgentName || event?.agentName || event?.label || childAgentId;
+      const spawnReason = event?.reason || event?.spawnReason || "unknown";
+      const parentAgentId = ctx?.agentId || event?.parentAgentId || "unknown";
+
+      // Resolved model/provider/runId are only present on `subagent_spawned`.
+      const resolvedModel = typeof event?.resolvedModel === "string" ? event.resolvedModel : undefined;
+      const resolvedProvider =
+        typeof event?.resolvedProvider === "string" ? event.resolvedProvider : undefined;
+      const runId = typeof event?.runId === "string" ? event.runId : undefined;
+
+      const sessionCtx = store.getActiveContext(parentSessionKey);
+      const stashKey = `__subagent_${childSessionKey}`;
+      const existing = sessionCtx?.activeToolSpans?.get(stashKey);
+
+      // Dedupe: the sibling hook already created the span. Enrich it with any
+      // resolved fields this event carries (so a `subagent_spawning`-created
+      // span still gains model/provider/runId from the later `subagent_spawned`
+      // firing), then stop — no second span, no double spawn count.
+      if (existing) {
+        applyResolvedSubagentFields(existing.span, resolvedModel, resolvedProvider, runId);
+        return;
+      }
+
+      const parentContext = store.resolveParentContext(childSessionKey)
+        || sessionCtx?.agentContext
+        || sessionCtx?.rootContext
+        || context.active();
+
+      const span = tracer.startSpan(
+        "openclaw.subagent.spawning",
+        {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
+            [GEN_AI_AGENT_ID]: childAgentId,
+            [GEN_AI_AGENT_NAME]: childAgentName,
+            [GEN_AI_CONVERSATION_ID]: childSessionKey,
+            [OC_SUBAGENT_PARENT_SESSION]: parentSessionKey,
+            [OC_SUBAGENT_CHILD_SESSION]: childSessionKey,
+            [OC_SUBAGENT_CHILD_AGENT_ID]: childAgentId,
+            [OC_SUBAGENT_CHILD_AGENT_NAME]: childAgentName,
+            [OC_SUBAGENT_SPAWN_REASON]: spawnReason,
+            ...codeAttrs(source),
+            "openclaw.session.key": parentSessionKey,
+            "openclaw.agent.id": parentAgentId,
+          },
+        },
+        parentContext,
+      );
+
+      applyResolvedSubagentFields(span, resolvedModel, resolvedProvider, runId);
+
+      store.linkSubAgent(childSessionKey, parentSessionKey);
+
+      // ISI-1627 / WS2 — trace propagation into the child is done IN-PROCESS
+      // via this parent↔child link: the child's `message_received` resolves
+      // the parent's live spawn-span context from the store and re-parents the
+      // child `openclaw.request` root under it, so both share one trace.id.
+      // OpenClaw fires the subagent spawn hooks with a fire-and-forget event
+      // object (no mutable `childSession` carrier on any runtime through
+      // v2026.6.11), so header (`traceparent`) injection across the spawn
+      // boundary is not possible from the plugin. Cross-process propagation
+      // would require an upstream pre-spawn mutable carrier (follow-up ask).
+
+      if (sessionCtx?.agentSpan) {
+        span.addLink({
+          context: sessionCtx.agentSpan.spanContext(),
+          attributes: { "openclaw.link.type": "subagent_parent" },
+        });
+      }
+
+      counters.subagentSpawns.add(1, {
+        [OC_SUBAGENT_CHILD_AGENT_NAME]: childAgentName,
+        [OC_SUBAGENT_SPAWN_REASON]: spawnReason,
+      });
+
+      if (sessionCtx) {
+        if (!sessionCtx.activeToolSpans) {
+          sessionCtx.activeToolSpans = new Map();
+        }
+        sessionCtx.activeToolSpans.set(stashKey, { span, startTime: Date.now() });
+      } else {
+        span.setStatus({ code: SpanStatusCode.OK });
+        span.end();
+      }
+
+      logger.debug?.(
+        `[otel] Sub-agent spawn (${source}): parent=${parentSessionKey}, child=${childSessionKey}, agent=${childAgentName}${runId ? `, runId=${runId}` : ""}`,
+      );
+    } catch {
+      // Never let telemetry break spawn.
+    }
+  }
+
+  api.on(
+    "subagent_spawned",
+    (event: any, ctx: any) => {
+      recordSubagentSpawn("subagent_spawned", event, ctx);
+      return undefined;
+    },
+    { priority: 60 },
+  );
+
+  logger.info("[otel] Registered subagent_spawned hook (via api.on)");
+
+  // Deprecated fallback — retained until upstream removeAfter 2026-08-30.
   api.on(
     "subagent_spawning",
     (event: any, ctx: any) => {
-      try {
-        const tel = getTelemetry();
-        if (!tel) return undefined;
-        const { tracer, counters } = tel;
-
-        const parentSessionKey = ctx?.sessionKey || event?.parentSessionKey || "unknown";
-        const childSessionKey = event?.childSessionKey || event?.sessionKey || "unknown";
-        const childAgentId = event?.childAgentId || event?.agentId || "unknown";
-        const childAgentName = event?.childAgentName || event?.agentName || childAgentId;
-        const spawnReason = event?.reason || event?.spawnReason || "unknown";
-        const parentAgentId = ctx?.agentId || event?.parentAgentId || "unknown";
-
-        const parentContext = store.resolveParentContext(childSessionKey)
-          || store.getActiveContext(parentSessionKey)?.agentContext
-          || store.getActiveContext(parentSessionKey)?.rootContext
-          || context.active();
-
-        const span = tracer.startSpan(
-          "openclaw.subagent.spawning",
-          {
-            kind: SpanKind.INTERNAL,
-            attributes: {
-              [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
-              [GEN_AI_AGENT_ID]: childAgentId,
-              [GEN_AI_AGENT_NAME]: childAgentName,
-              [GEN_AI_CONVERSATION_ID]: childSessionKey,
-              [OC_SUBAGENT_PARENT_SESSION]: parentSessionKey,
-              [OC_SUBAGENT_CHILD_SESSION]: childSessionKey,
-              [OC_SUBAGENT_CHILD_AGENT_ID]: childAgentId,
-              [OC_SUBAGENT_CHILD_AGENT_NAME]: childAgentName,
-              [OC_SUBAGENT_SPAWN_REASON]: spawnReason,
-              ...codeAttrs("subagent_spawning"),
-              "openclaw.session.key": parentSessionKey,
-              "openclaw.agent.id": parentAgentId,
-            },
-          },
-          parentContext
-        );
-
-        store.linkSubAgent(childSessionKey, parentSessionKey);
-
-        // ISI-1021: Inject W3C trace context into child session metadata
-        // so the subagent can extract it and continue the trace.
-        const traceHeaders: Record<string, string> = {};
-        injectTraceContext(traceHeaders, context.active());
-        if (traceHeaders.traceparent && event.childSession) {
-          event.childSession.traceContext = {
-            traceparent: traceHeaders.traceparent,
-            tracestate: traceHeaders.tracestate,
-          };
-          logger.debug?.(`[otel] Injected traceparent into child session: ${traceHeaders.traceparent}`);
-        }
-
-        if (store.getActiveContext(parentSessionKey)?.agentSpan) {
-          const parentSpan = store.getActiveContext(parentSessionKey)!.agentSpan!;
-          span.addLink({
-            context: parentSpan.spanContext(),
-            attributes: { "openclaw.link.type": "subagent_parent" },
-          });
-        }
-
-        counters.subagentSpawns.add(1, {
-          [OC_SUBAGENT_CHILD_AGENT_NAME]: childAgentName,
-          [OC_SUBAGENT_SPAWN_REASON]: spawnReason,
-        });
-
-        const sessionCtx = store.getActiveContext(parentSessionKey);
-        if (sessionCtx) {
-          if (!sessionCtx.activeToolSpans) {
-            sessionCtx.activeToolSpans = new Map();
-          }
-          sessionCtx.activeToolSpans.set(`__subagent_${childSessionKey}`, {
-            span,
-            startTime: Date.now(),
-          });
-        } else {
-          span.setStatus({ code: SpanStatusCode.OK });
-          span.end();
-        }
-
-        logger.debug?.(`[otel] Sub-agent spawning: parent=${parentSessionKey}, child=${childSessionKey}, agent=${childAgentName}`);
-      } catch {
-      }
-
+      recordSubagentSpawn("subagent_spawning", event, ctx);
       return undefined;
     },
-    { priority: 60 }
+    { priority: 60 },
   );
 
-  logger.info("[otel] Registered subagent_spawning hook (via api.on)");
+  logger.info("[otel] Registered subagent_spawning fallback hook (via api.on)");
 
   // ── subagent_delivery_target ──────────────────────────────────────
   // Fires when the parent delivers a target (task/prompt) to the child

--- a/src/semconv.ts
+++ b/src/semconv.ts
@@ -156,6 +156,13 @@ export const OC_SUBAGENT_CHILD_SESSION = "openclaw.subagent.child_session_key";
 export const OC_SUBAGENT_CHILD_AGENT_ID = "openclaw.subagent.child_agent_id";
 export const OC_SUBAGENT_CHILD_AGENT_NAME = "openclaw.subagent.child_agent_name";
 export const OC_SUBAGENT_SPAWN_REASON = "openclaw.subagent.spawn_reason";
+/**
+ * OpenClaw run id of the spawned subagent (ISI-1627 / WS1). Sourced from the
+ * `subagent_spawned` hook's `runId`; absent on the deprecated
+ * `subagent_spawning` hook. Correlates the subagent span with the runtime's
+ * run-scoped logs/metrics.
+ */
+export const OC_SUBAGENT_RUN_ID = "openclaw.subagent.run_id";
 export const OC_SUBAGENT_DELIVERY_TYPE = "openclaw.subagent.delivery_type";
 export const OC_SUBAGENT_SUCCESS = "openclaw.subagent.success";
 export const OC_SUBAGENT_DURATION_MS = "openclaw.subagent.duration_ms";
@@ -170,6 +177,16 @@ export const OC_CRON_AGENT_ID = "openclaw.cron.agent_id";
 /**
  * Schema version for plugin-domain attributes. Bump when emitted
  * attribute keys or values change in a way that consumers need to know.
+ *
+ * `1.5.0` (ISI-1627) — Additive only. Adds `openclaw.subagent.run_id` and
+ * sets the stable `gen_ai.request.model` + `gen_ai.provider.name` keys on the
+ * subagent spawn span, sourced from the new `subagent_spawned` hook's
+ * `runId` / `resolvedModel` / `resolvedProvider` fields (model/provider
+ * previously resolved to "unknown" on the deprecated `subagent_spawning`
+ * hook). No `minOpenClawVersion` bump — the new fields are read defensively
+ * and absent-field access is harmless. No 1.4.0 key was removed or renamed.
+ * (Sibling ISI-1628 / ISI-1629 also target `1.5.0`; whichever PR merges first
+ * introduces the bump and the others reconcile this note.)
  *
  * `1.4.0` (ISI-1605) — Additive only. Adds opt-in GenAI content-capture
  * keys aligned to Dynatrace AI Observability (`gen_ai.input.messages`,
@@ -194,7 +211,7 @@ export const OC_CRON_AGENT_ID = "openclaw.cron.agent_id";
  * | `gen_ai.usage.cache_write_tokens`     | `gen_ai.usage.cache_creation.input_tokens`                               |
  * | `gen_ai.usage.total_tokens`           | none — consumers compute `input + output` (per `1.2.0` deprecation note) |
  */
-export const OPENCLAW_SCHEMA_VERSION = "1.4.0";
+export const OPENCLAW_SCHEMA_VERSION = "1.5.0";
 
 // ── Token type values ───────────────────────────────────────────────
 export const TOKEN_TYPE_INPUT = "input";

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trace } from "@opentelemetry/api";
 import type { Counter, Histogram, Span, Tracer, UpDownCounter } from "@opentelemetry/api";
 
 import { registerHooks } from "../src/hooks.js";
@@ -28,14 +29,22 @@ interface SpanSpy {
   ended: boolean;
   status: { code?: number; message?: string };
   spanName: string;
+  /** Parent context passed to `tracer.startSpan` (undefined = trace root). */
+  parentContext?: unknown;
+  /** Unique span id so propagation/parenting can be asserted. */
+  id: string;
 }
 
+let spanSeq = 0;
+
 function createSpanSpy(name: string): Span & SpanSpy {
+  const id = `span-${++spanSeq}`;
   const spy: SpanSpy = {
     attrs: {},
     ended: false,
     status: {},
     spanName: name,
+    id,
   };
   const span = {
     ...spy,
@@ -78,7 +87,7 @@ function createSpanSpy(name: string): Span & SpanSpy {
       return !spy.ended;
     },
     spanContext() {
-      return { traceId: "t", spanId: "s", traceFlags: 1 };
+      return { traceId: "t", spanId: id, traceFlags: 1 };
     },
   };
   return span as unknown as Span & SpanSpy;
@@ -87,11 +96,16 @@ function createSpanSpy(name: string): Span & SpanSpy {
 function createTracerSpy(): { tracer: Tracer; spans: Array<Span & SpanSpy> } {
   const spans: Array<Span & SpanSpy> = [];
   const tracer = {
-    startSpan(name: string, options?: { attributes?: Record<string, unknown> }) {
+    startSpan(
+      name: string,
+      options?: { attributes?: Record<string, unknown> },
+      parentContext?: unknown,
+    ) {
       const span = createSpanSpy(name);
       if (options?.attributes) {
         Object.assign((span as unknown as SpanSpy).attrs, options.attributes);
       }
+      (span as unknown as SpanSpy).parentContext = parentContext;
       spans.push(span);
       return span;
     },
@@ -1862,12 +1876,21 @@ describe("hook registration includes all new lifecycle hooks (ISI-928)", () => {
 describe("subagent_spawning / subagent_delivery_target / subagent_ended hooks (ISI-929)", () => {
   let stopHooks: () => void;
 
+  // The trace-context store is a process-global singleton (survives plugin
+  // reloads by design). These tests reuse fixed session keys, so reset it
+  // between cases for isolation — otherwise a spawn span stashed by one test
+  // leaks into the next and the ISI-1627 spawn dedupe short-circuits it.
+  beforeEach(() => {
+    (globalThis as Record<string, any>)["__openclaw_otel_trace_context_store__"]?.clear();
+  });
+
   it("registers all sub-agent hooks", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry } = createTelemetry();
     stopHooks = registerHooks(api, () => telemetry, config);
 
     expect(typedHooks.has("subagent_spawning")).toBe(true);
+    expect(typedHooks.has("subagent_spawned")).toBe(true);
     expect(typedHooks.has("subagent_delivery_target")).toBe(true);
     expect(typedHooks.has("subagent_ended")).toBe(true);
 
@@ -2083,6 +2106,188 @@ describe("subagent_spawning / subagent_delivery_target / subagent_ended hooks (I
     );
 
     expect(spawnSpan!.ended).toBe(true);
+
+    stopHooks();
+  });
+});
+
+describe("subagent_spawned migration + end-to-end trace propagation (ISI-1627)", () => {
+  let stopHooks: () => void;
+
+  beforeEach(() => {
+    (globalThis as Record<string, any>)["__openclaw_otel_trace_context_store__"]?.clear();
+  });
+
+  it("subagent_spawned creates a spawn span with resolved model / provider / run_id", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const spawned = typedHooks.get("subagent_spawned")!;
+
+    resolve({}, { agentId: "parent-agent", sessionKey: "parent-sess" });
+
+    const result = spawned(
+      {
+        runId: "run-42",
+        childSessionKey: "child-sess",
+        agentId: "child-agent-id",
+        label: "child-agent",
+        resolvedModel: "anthropic/claude-opus-4",
+        resolvedProvider: "anthropic",
+      },
+      { sessionKey: "parent-sess", requesterSessionKey: "parent-sess" },
+    );
+    expect(result).toBeUndefined();
+
+    const spawnSpan = spans.find((s) => s.spanName === "openclaw.subagent.spawning");
+    expect(spawnSpan).toBeDefined();
+    expect(spawnSpan!.attrs["openclaw.subagent.child_session_key"]).toBe("child-sess");
+    expect(spawnSpan!.attrs["openclaw.subagent.child_agent_id"]).toBe("child-agent-id");
+    expect(spawnSpan!.attrs["openclaw.subagent.child_agent_name"]).toBe("child-agent");
+    // ISI-1627 / WS1 — resolved fields land on the subagent span.
+    expect(spawnSpan!.attrs["gen_ai.request.model"]).toBe("anthropic/claude-opus-4");
+    expect(spawnSpan!.attrs["gen_ai.provider.name"]).toBe("anthropic");
+    expect(spawnSpan!.attrs["openclaw.subagent.run_id"]).toBe("run-42");
+    expect(spawnSpan!.attrs["code.function.name"]).toBe("openclaw.otel.hooks.subagent_spawned");
+    expect(spawnSpan!.ended).toBe(false);
+
+    expect(telemetry.counters.subagentSpawns.add).toHaveBeenCalledTimes(1);
+
+    stopHooks();
+  });
+
+  it("dedupes subagent_spawning + subagent_spawned into ONE span, enriched with resolved fields", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const spawning = typedHooks.get("subagent_spawning")!;
+    const spawned = typedHooks.get("subagent_spawned")!;
+
+    resolve({}, { agentId: "parent-agent", sessionKey: "parent-sess" });
+
+    // Modern runtime fires BOTH: spawning first (pre-spawn, no resolved
+    // fields), then spawned (post-spawn, carries resolved fields).
+    spawning(
+      { childSessionKey: "child-sess", childAgentId: "c", childAgentName: "c", reason: "delegation" },
+      { sessionKey: "parent-sess", agentId: "parent-agent" },
+    );
+    spawned(
+      {
+        runId: "run-9",
+        childSessionKey: "child-sess",
+        agentId: "c",
+        label: "c",
+        resolvedModel: "anthropic/claude-sonnet-4",
+        resolvedProvider: "anthropic",
+      },
+      { sessionKey: "parent-sess" },
+    );
+
+    const spawnSpans = spans.filter((s) => s.spanName === "openclaw.subagent.spawning");
+    expect(spawnSpans).toHaveLength(1); // single span — no double emit
+    // The spawning-created span was enriched by the later spawned firing.
+    expect(spawnSpans[0].attrs["gen_ai.request.model"]).toBe("anthropic/claude-sonnet-4");
+    expect(spawnSpans[0].attrs["gen_ai.provider.name"]).toBe("anthropic");
+    expect(spawnSpans[0].attrs["openclaw.subagent.run_id"]).toBe("run-9");
+    // Counted exactly once despite two hook firings.
+    expect(telemetry.counters.subagentSpawns.add).toHaveBeenCalledTimes(1);
+
+    stopHooks();
+  });
+
+  it("dedupe is order-independent (spawned first, then spawning) — one span, one count", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const resolve = typedHooks.get("before_model_resolve")!;
+    const spawning = typedHooks.get("subagent_spawning")!;
+    const spawned = typedHooks.get("subagent_spawned")!;
+
+    resolve({}, { agentId: "parent-agent", sessionKey: "parent-sess" });
+
+    spawned(
+      { runId: "run-3", childSessionKey: "child-sess", agentId: "c", label: "c", resolvedModel: "m", resolvedProvider: "p" },
+      { sessionKey: "parent-sess" },
+    );
+    spawning(
+      { childSessionKey: "child-sess", childAgentId: "c", childAgentName: "c", reason: "delegation" },
+      { sessionKey: "parent-sess", agentId: "parent-agent" },
+    );
+
+    expect(spans.filter((s) => s.spanName === "openclaw.subagent.spawning")).toHaveLength(1);
+    expect(telemetry.counters.subagentSpawns.add).toHaveBeenCalledTimes(1);
+
+    stopHooks();
+  });
+
+  it("re-parents the child openclaw.request under the parent spawn span (shared trace end-to-end)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const messageReceived = typedHooks.get("message_received")!;
+    const spawned = typedHooks.get("subagent_spawned")!;
+
+    // Parent turn establishes an active context + root span.
+    messageReceived({ sessionKey: "parent-sess", text: "hi" }, {});
+    const parentRoot = spans.find(
+      (s) => s.spanName === "openclaw.request" && s.attrs["openclaw.session.key"] === "parent-sess",
+    )!;
+    expect(parentRoot).toBeDefined();
+
+    // Parent spawns a child — links child→parent and stashes the spawn span.
+    spawned(
+      { runId: "run-1", childSessionKey: "child-sess", agentId: "c", label: "c" },
+      { sessionKey: "parent-sess" },
+    );
+    const spawnSpan = spans.find((s) => s.spanName === "openclaw.subagent.spawning")!;
+    expect(spawnSpan).toBeDefined();
+
+    // Child's first inbound message must JOIN the same trace, nested under
+    // the spawn span — not start a fresh trace root.
+    messageReceived({ sessionKey: "child-sess", text: "work" }, {});
+    const childRoot = spans.find(
+      (s) => s.spanName === "openclaw.request" && s.attrs["openclaw.session.key"] === "child-sess",
+    )!;
+    expect(childRoot).toBeDefined();
+
+    // The child request span was created WITH a parent context...
+    expect(childRoot.parentContext).toBeDefined();
+    // ...resolving to the subagent spawn span (shared trace lineage).
+    expect(trace.getSpanContext(childRoot.parentContext as any)?.spanId).toBe(spawnSpan.id);
+
+    // Sanity: the parent request span itself remained a trace root.
+    expect(trace.getSpanContext(parentRoot.parentContext as any)).toBeUndefined();
+
+    stopHooks();
+  });
+
+  it("re-parents the child openclaw.request from an incoming W3C traceparent when present", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const messageReceived = typedHooks.get("message_received")!;
+
+    // Cross-process ingress: message carries a W3C traceparent.
+    const traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    messageReceived(
+      { sessionKey: "ingress-sess", text: "hi", metadata: { traceparent } },
+      {},
+    );
+    const root = spans.find(
+      (s) => s.spanName === "openclaw.request" && s.attrs["openclaw.session.key"] === "ingress-sess",
+    )!;
+    expect(root).toBeDefined();
+    // Parented into the incoming trace (not a fresh root).
+    expect(trace.getSpanContext(root.parentContext as any)?.traceId).toBe(
+      "0af7651916cd43dd8448eb211c80319c",
+    );
 
     stopHooks();
   });

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -2225,6 +2225,72 @@ describe("subagent_spawned migration + end-to-end trace propagation (ISI-1627)",
     stopHooks();
   });
 
+  it("dedupes both hooks with NO parent session context — one span, one count, resolved fields kept (ISI-1633)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const spawning = typedHooks.get("subagent_spawning")!;
+    const spawned = typedHooks.get("subagent_spawned")!;
+
+    // NOTE: no before_model_resolve / message_received for "parent-sess", so the
+    // parent has NO active session context. Both hooks still fire (modern
+    // runtime): spawning first (no resolved fields), then spawned. Without the
+    // orphan-holding dedup this produced TWO spans + double count and dropped
+    // the resolved model/provider/run_id.
+    spawning(
+      { childSessionKey: "child-sess", childAgentId: "c", childAgentName: "c", reason: "delegation" },
+      { sessionKey: "parent-sess", agentId: "parent-agent" },
+    );
+    spawned(
+      {
+        runId: "run-77",
+        childSessionKey: "child-sess",
+        agentId: "c",
+        label: "c",
+        resolvedModel: "anthropic/claude-opus-4",
+        resolvedProvider: "anthropic",
+      },
+      { sessionKey: "parent-sess" },
+    );
+
+    const spawnSpans = spans.filter((s) => s.spanName === "openclaw.subagent.spawning");
+    expect(spawnSpans).toHaveLength(1); // single span despite two firings, no sessionCtx
+    expect(telemetry.counters.subagentSpawns.add).toHaveBeenCalledTimes(1); // counted once
+    // Resolved fields from the later spawned firing survive on the held span.
+    expect(spawnSpans[0].attrs["gen_ai.request.model"]).toBe("anthropic/claude-opus-4");
+    expect(spawnSpans[0].attrs["gen_ai.provider.name"]).toBe("anthropic");
+    expect(spawnSpans[0].attrs["openclaw.subagent.run_id"]).toBe("run-77");
+
+    stopHooks();
+  });
+
+  it("subagent_ended closes an orphan spawn span held with no parent session context (ISI-1633)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const spawned = typedHooks.get("subagent_spawned")!;
+    const ended = typedHooks.get("subagent_ended")!;
+
+    spawned(
+      { runId: "run-5", childSessionKey: "child-sess", agentId: "c", label: "c", resolvedModel: "m", resolvedProvider: "p" },
+      { sessionKey: "parent-sess" },
+    );
+    const spawnSpan = spans.find((s) => s.spanName === "openclaw.subagent.spawning")!;
+    expect(spawnSpan).toBeDefined();
+    expect(spawnSpan.ended).toBe(false); // held open, not ended immediately
+
+    ended(
+      { childSessionKey: "child-sess", childAgentName: "c", success: true, durationMs: 12 },
+      { sessionKey: "parent-sess" },
+    );
+    expect(spawnSpan.ended).toBe(true); // closed by subagent_ended via the orphan map
+    expect(spawnSpan.attrs["openclaw.subagent.duration_ms"]).toBe(12);
+
+    stopHooks();
+  });
+
   it("re-parents the child openclaw.request under the parent spawn span (shared trace end-to-end)", () => {
     const { api, typedHooks } = createStubApi();
     const { telemetry, spans } = createTelemetry();


### PR DESCRIPTION
**Issue:** ISI-1627 (WS1+WS2, child of ISI-1609 rev2). WS1 and WS2 are coupled — the hook migration moves the trace-injection site — so they ship together.

## WS1 — `subagent_spawning` → `subagent_spawned` migration ⏰ (removeAfter 2026-08-30)
- New `subagent_spawned` handler; both hooks funnel through a shared `recordSubagentSpawn` that emits **one** span per `childSessionKey`, deduping on the parent's `__subagent_<childSessionKey>` slot. First hook to fire creates the span + spawn counter; a later sibling firing only **enriches** it → a runtime firing both never double-emits or double-counts.
- Records the `subagent_spawned`-only fields: `resolvedModel` → `gen_ai.request.model`, `resolvedProvider` → `gen_ai.provider.name`, `runId` → `openclaw.subagent.run_id` (model/provider previously resolved to `"unknown"`).
- `subagent_spawning` retained as a **deduped fallback** for runtimes below the `subagent_spawned` floor. **No `minOpenClawVersion` bump.**

## WS2 — end-to-end trace propagation fix
- **Re-parent** the child `openclaw.request` root: parent context resolved **before** `startSpan` and passed as parent, instead of a fresh root + link.
- Propagation is **in-process** via the store's parent↔child link — the child's `message_received` resolves the parent's live **spawn-span** context and nests the child request under it → one shared `trace.id` end-to-end (parent turn → spawn → child request → child tools). Incoming `traceparent` kept as a secondary cross-process source + link.
- **Removed the dead `event.childSession.traceContext` injection.** Verified against fork `hook-types.ts` across `v2026.4.21 → v2026.6.11`: the spawn hooks fire a fire-and-forget event with **no mutable `childSession` carrier**, so header injection across the spawn boundary was a no-op. Resolves the **WS2.3 open risk**; true cross-process propagation would need an upstream pre-spawn mutable carrier (follow-up upstream ask).

## Semconv
Adds `openclaw.subagent.run_id`; sets `gen_ai.request.model` + `gen_ai.provider.name` on the subagent span. `OPENCLAW_SCHEMA_VERSION` `1.4.0 → 1.5.0` (additive). Coordinated with siblings ISI-1628/1629 — first PR to merge introduces `1.5.0`.

## Verification
- `tsc --noEmit` clean; **285 tests pass** (+5 new: spawned span fields, dedupe both orders, child re-parent under spawn span, `traceparent` ingress re-parent).
- ⏳ **Acceptance validation (single `trace.id` capture) is owned by the Observability Agent** via Dynatrace MCP/DQL after a staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)