### PR TITLE
feat(diagnostics): memory.sample + memory.pressure event support

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -331,6 +331,37 @@ export async function registerDiagnosticsListener(
       return;
     }
 
+    // Memory sample events — record memory usage histograms
+    if (evt.type === "diagnostic.memory.sample") {
+      if (evt.memory) {
+        if (typeof evt.memory.rssBytes === "number") histograms.memoryRssBytes.record(evt.memory.rssBytes);
+        if (typeof evt.memory.heapUsedBytes === "number") histograms.memoryHeapUsedBytes.record(evt.memory.heapUsedBytes);
+        if (typeof evt.memory.heapTotalBytes === "number") histograms.memoryHeapTotalBytes.record(evt.memory.heapTotalBytes);
+        if (typeof evt.memory.externalBytes === "number") histograms.memoryExternalBytes.record(evt.memory.externalBytes);
+        if (typeof evt.memory.arrayBuffersBytes === "number") histograms.memoryArrayBuffersBytes.record(evt.memory.arrayBuffersBytes);
+      }
+      logger.debug?.(`[otel] diagnostic.memory.sample: rss=${evt.memory?.rssBytes}, heapUsed=${evt.memory?.heapUsedBytes}`);
+      return;
+    }
+
+    // Memory pressure events
+    if (evt.type === "diagnostic.memory.pressure") {
+      const attrs: Record<string, string> = {};
+      if (evt.reason) attrs["openclaw.memory.reason"] = evt.reason;
+      if (evt.level) attrs["openclaw.memory.level"] = evt.level;
+      counters.memoryPressure.add(1, attrs);
+      // Also record memory snapshot if available
+      if (evt.memory) {
+        if (typeof evt.memory.rssBytes === "number") histograms.memoryRssBytes.record(evt.memory.rssBytes);
+        if (typeof evt.memory.heapUsedBytes === "number") histograms.memoryHeapUsedBytes.record(evt.memory.heapUsedBytes);
+        if (typeof evt.memory.heapTotalBytes === "number") histograms.memoryHeapTotalBytes.record(evt.memory.heapTotalBytes);
+        if (typeof evt.memory.externalBytes === "number") histograms.memoryExternalBytes.record(evt.memory.externalBytes);
+        if (typeof evt.memory.arrayBuffersBytes === "number") histograms.memoryArrayBuffersBytes.record(evt.memory.arrayBuffersBytes);
+      }
+      logger.debug?.(`[otel] diagnostic.memory.pressure: reason=${evt.reason}, level=${evt.level}`);
+      return;
+    }
+
     if (evt.type !== "model.usage") return;
 
     const sessionKey = evt.sessionKey || "unknown";

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -646,9 +646,10 @@ export function registerHooks(
         );
 
         const agentContext = trace.setSpan(parentContext, agentSpan);
-        // DIAG: verify SDK sees the parent correctly
+        // DIAG: log parent context at debug to help trace orphan-span investigations
         const parentSpanCtx = trace.getSpanContext(parentContext);
-        logger.info(`[otel] DIAG agent turn: parentSpanCtx=${JSON.stringify(parentSpanCtx)}, parentContextHasSpan=${!!trace.getSpan(parentContext)}, agentSpanContext=${JSON.stringify(agentSpan.spanContext())}`);
+        logger.debug?.(`[otel] DIAG agent turn: parentSpanCtx=${JSON.stringify(parentSpanCtx)}, parentContextHasSpan=${!!trace.getSpan(parentContext)}, agentSpanContext=${JSON.stringify(agentSpan.spanContext())}`);
+        logger.info(`[otel] Agent turn span created: spanId=${agentSpan.spanContext().spanId}, isRecording=${agentSpan.isRecording()}`);
 
         // Store agent span context for tool spans
         if (sessionCtx) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -501,7 +501,7 @@ export function registerHooks(
           "openclaw.session.channel": channel,
         });
 
-        logger.debug?.(`[otel] Session span started: session=${sessionKey}, agent=${agentId}`);
+        logger.info(`[otel] Session span started: session=${sessionKey}, agent=${agentId}`);
       } catch {
       }
     },
@@ -646,7 +646,9 @@ export function registerHooks(
         );
 
         const agentContext = trace.setSpan(parentContext, agentSpan);
-        logger.info(`[otel] Agent turn span created: spanId=${agentSpan.spanContext().spanId}, isRecording=${agentSpan.isRecording()}`);
+        // DIAG: verify SDK sees the parent correctly
+        const parentSpanCtx = trace.getSpanContext(parentContext);
+        logger.info(`[otel] DIAG agent turn: parentSpanCtx=${JSON.stringify(parentSpanCtx)}, parentContextHasSpan=${!!trace.getSpan(parentContext)}, agentSpanContext=${JSON.stringify(agentSpan.spanContext())}`);
 
         // Store agent span context for tool spans
         if (sessionCtx) {
@@ -823,6 +825,9 @@ export function registerHooks(
         const provider = event?.provider || ctx?.provider || "unknown";
 
         const sessionCtx = store.getActiveContext(sessionKey);
+        if (!sessionCtx) {
+          logger.warn(`[otel] DIAG llm_input: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount}, eventKeys=${Object.keys(event || {}).join(',')}, ctxKeys=${Object.keys(ctx || {}).join(',')}`);
+        }
         // If llm_input fires without a prior agent span (unusual), fall back
         // to root context so the CLIENT span still attaches to the trace.
         const parentContext =
@@ -982,7 +987,46 @@ export function registerHooks(
         const stream = event?.stream;
         const maxTokens = event?.maxTokens;
 
-        const sessionCtx = store.getActiveContext(sessionKey);
+        let sessionCtx = store.getActiveContext(sessionKey);
+        if (!sessionCtx) {
+          logger.warn(`[otel] model_call_started: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount} — creating synthetic root (likely post-compaction retry)`);
+          // Auto-compaction retries skip message_received and before_model_resolve.
+          // Create a synthetic root span + agent turn so child spans get proper parents.
+          const rootSpan = tracer.startSpan("openclaw.request", {
+            kind: SpanKind.SERVER,
+            attributes: {
+              [GEN_AI_CONVERSATION_ID]: sessionKey,
+              "openclaw.session.key": sessionKey,
+              "openclaw.trigger": ctx?.trigger || "compaction_retry",
+              "openclaw.agent.id": agentId,
+              "openclaw.compaction_retry": true,
+            },
+          });
+          const rootContext = trace.setSpan(context.active(), rootSpan);
+          store.setActiveContext(sessionKey, {
+            rootSpan,
+            rootContext,
+            startTime: Date.now(),
+          });
+          // Also create agent turn span
+          const agentSpan = tracer.startSpan(
+            "openclaw.agent.turn",
+            { kind: SpanKind.INTERNAL, attributes: {
+              [GEN_AI_OPERATION_NAME]: OP_INVOKE_AGENT,
+              [GEN_AI_AGENT_ID]: agentId,
+              [GEN_AI_CONVERSATION_ID]: sessionKey,
+              "openclaw.agent.id": agentId,
+              "openclaw.session.key": sessionKey,
+              "openclaw.compaction_retry": true,
+            } },
+            rootContext
+          );
+          const agentContext = trace.setSpan(rootContext, agentSpan);
+          sessionCtx = store.getActiveContext(sessionKey)!;
+          sessionCtx.agentSpan = agentSpan;
+          sessionCtx.agentContext = agentContext;
+          logger.info(`[otel] Created synthetic root+agent span for compaction retry: root=${rootSpan.spanContext().spanId}, agent=${agentSpan.spanContext().spanId}`);
+        }
         const parentContext =
           sessionCtx?.agentContext || sessionCtx?.rootContext || context.active();
 
@@ -1158,6 +1202,9 @@ export function registerHooks(
         const provider = event?.provider || ctx?.provider || "unknown";
 
         const sessionCtx = store.getActiveContext(sessionKey);
+        if (!sessionCtx) {
+          logger.warn(`[otel] DIAG before_dispatch: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount}, eventKeys=${Object.keys(event || {}).join(',')}, ctxKeys=${Object.keys(ctx || {}).join(',')}`);
+        }
         const parentContext =
           sessionCtx?.agentContext || sessionCtx?.rootContext || context.active();
 
@@ -1267,6 +1314,9 @@ export function registerHooks(
         const requiresApproval = event?.requiresApproval === true;
 
         const sessionCtx = store.getActiveContext(sessionKey);
+        if (!sessionCtx) {
+          logger.warn(`[otel] DIAG before_tool_call: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount}, eventKeys=${Object.keys(event || {}).join(',')}, ctxKeys=${Object.keys(ctx || {}).join(',')}`);
+        }
         const parentContext = sessionCtx?.agentContext || sessionCtx?.rootContext || context.active();
 
         const span = tracer.startSpan(
@@ -1672,6 +1722,9 @@ export function registerHooks(
           typeof messageText === "string" ? messageText.length : 0;
 
         const sessionCtx = store.getActiveContext(sessionKey);
+        if (!sessionCtx) {
+          logger.warn(`[otel] DIAG message_sent: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount}, eventKeys=${Object.keys(event || {}).join(',')}, ctxKeys=${Object.keys(ctx || {}).join(',')}`);
+        }
         const parentContext =
           sessionCtx?.rootContext || sessionCtx?.agentContext || context.active();
 
@@ -1718,7 +1771,7 @@ export function registerHooks(
         span.setStatus({ code: SpanStatusCode.OK });
         span.end();
 
-        logger.debug?.(`[otel] Outbound message span recorded: session=${sessionKey}, channel=${channel}, chars=${charCount}`);
+        logger.info(`[otel] Outbound message span recorded: session=${sessionKey}, channel=${channel}, chars=${charCount}`);
       } catch {
         // Never let telemetry errors break the main flow
       }
@@ -3074,6 +3127,7 @@ export function registerHooks(
         });
         span.setStatus({ code: SpanStatusCode.OK });
         span.end();
+        logger.info(`[otel] Gateway startup span recorded`);
       } catch {
         // Silently ignore
       }
@@ -3091,7 +3145,7 @@ export function registerHooks(
   // The handle is returned to the caller so service.stop() can clear it and
   // avoid leaking timers across plugin reload / shutdown.
   const cleanupInterval = setInterval(() => {
-    const maxAge = 5 * 60 * 1000;
+    const maxAge = 30 * 60 * 1000;
     const cleaned = store.cleanupStale(maxAge);
     if (cleaned > 0) {
       logger.debug?.(`[otel] Cleaned up ${cleaned} stale trace contexts`);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -204,6 +204,8 @@ export interface OtelCounters {
   webhooksErrors: Counter;
   /** Compaction events (attr: reason) — ISI-1628 */
   compactionCount: Counter;
+  /** Memory pressure events */
+  memoryPressure: Counter;
 }
 
 export interface OtelHistograms {
@@ -247,6 +249,16 @@ export interface OtelHistograms {
   webhookPayloadSize: Histogram;
   /** Tokens reclaimed by a compaction event — ISI-1628 */
   compactionTokensReclaimed: Histogram;
+  /** Memory: resident set size in bytes */
+  memoryRssBytes: Histogram;
+  /** Memory: heap used in bytes */
+  memoryHeapUsedBytes: Histogram;
+  /** Memory: heap total in bytes */
+  memoryHeapTotalBytes: Histogram;
+  /** Memory: external in bytes */
+  memoryExternalBytes: Histogram;
+  /** Memory: array buffers in bytes */
+  memoryArrayBuffersBytes: Histogram;
 }
 
 export interface OtelGauges {
@@ -584,6 +596,10 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
       description: "Total context-compaction events",
       unit: "events",
     }),
+    memoryPressure: meter.createCounter("openclaw.memory.pressure", {
+      description: "Diagnostic memory pressure events",
+      unit: "1",
+    }),
   };
 
   const toolDuration = meter.createHistogram("openclaw.tool.duration", {
@@ -671,6 +687,27 @@ export function initTelemetry(config: OtelObservabilityConfig, logger: any): Tel
     compactionTokensReclaimed: meter.createHistogram("openclaw.compaction.tokens_reclaimed", {
       description: "Tokens reclaimed by a context-compaction event",
       unit: "{token}",
+    }),
+    // Memory histograms (diagnostic.memory.sample events)
+    memoryRssBytes: meter.createHistogram("openclaw.memory.rss_bytes", {
+      description: "Resident set size reported by diagnostic memory samples",
+      unit: "By",
+    }),
+    memoryHeapUsedBytes: meter.createHistogram("openclaw.memory.heap_used_bytes", {
+      description: "Heap used bytes reported by diagnostic memory samples",
+      unit: "By",
+    }),
+    memoryHeapTotalBytes: meter.createHistogram("openclaw.memory.heap_total_bytes", {
+      description: "Heap total bytes reported by diagnostic memory samples",
+      unit: "By",
+    }),
+    memoryExternalBytes: meter.createHistogram("openclaw.memory.external_bytes", {
+      description: "External memory bytes reported by diagnostic memory samples",
+      unit: "By",
+    }),
+    memoryArrayBuffersBytes: meter.createHistogram("openclaw.memory.array_buffers_bytes", {
+      description: "ArrayBuffer bytes reported by diagnostic memory samples",
+      unit: "By",
     }),
   };
 


### PR DESCRIPTION
Adds memory diagnostics: memory.sample/pressure events → histograms + counters, DIAG logging for missing sessionCtx, synthetic spans for compaction retries, stale cleanup 5→30min. Deployed on clawdbot for live validation.