### PR TITLE
docs(ISI-1646): refresh README/docs/CHANGELOG for 0.7.0 + 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,21 @@ All notable changes to the `@henrikrexed/openclaw-otel-observability` plugin are
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Merged in code review but not yet in a tagged release. Additive — no keys removed or renamed. The plugin-domain attribute schema (`openclaw.schema.version`) advances to `1.5.0`.
+
+### Features
+
+* **ISI-1629:** tool-span enrichment — `openclaw.tool.kind`, `openclaw.tool.input_kind`, and bounded/redacted `openclaw.tool.derived_paths`, read from the already-subscribed `before_tool_call` hook (tool attribution + file blast-radius analysis)
+
 ## [0.8.0](https://github.com/henrikrexed/openclaw-observability-plugin/compare/v0.7.0...v0.8.0) (2026-07-08)
 
 
 ### Features
 
-* **ISI-1605:** gen_ai content semconv keys for Dynatrace AI Observability ([c41734f](https://github.com/henrikrexed/openclaw-observability-plugin/commit/c41734f328e2ca22afd775731497528962bd6f09))
 * **ISI-1605:** gen_ai content semconv keys for Dynatrace AI Observability ([e5a6ecf](https://github.com/henrikrexed/openclaw-observability-plugin/commit/e5a6ecf8903d7f1a92761201a9f37443d882b2bb))
-* **ISI-1627:** subagent_spawned migration + end-to-end trace propagation ([b7ebd08](https://github.com/henrikrexed/openclaw-observability-plugin/commit/b7ebd08044410104c3e2af085ef0c6b15f128cba))
 * **ISI-1627:** subagent_spawned migration + end-to-end trace propagation ([0bda813](https://github.com/henrikrexed/openclaw-observability-plugin/commit/0bda813d3f3c162b03b32657835bdcbd1ce6b216))
-* **ISI-1628:** compaction spans + metrics (before/after_compaction) ([c6343f6](https://github.com/henrikrexed/openclaw-observability-plugin/commit/c6343f6c0bbbfa1664c73513fe561527dd636ee5))
 * **ISI-1628:** compaction spans + metrics (before/after_compaction) ([6684ad4](https://github.com/henrikrexed/openclaw-observability-plugin/commit/6684ad4c4cfe79f10caedae644abfa3b2090cfba))
 
 
@@ -26,8 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Features
 
-* **ISI-1318:** bounded redacted error_preview on failed tool spans ([bebeafe](https://github.com/henrikrexed/openclaw-observability-plugin/commit/bebeafef30f6953fb2b528e768568c6d5585e19c))
-* **ISI-1318:** bounded redacted error_preview on failed tool spans ([5874839](https://github.com/henrikrexed/openclaw-observability-plugin/commit/58748393b715abd968fe90a135d650ebdf53bd34))
+* **ISI-1318:** bounded redacted error_preview on failed tool spans, gated by the new `captureContent.toolErrorMessages` flag ([5874839](https://github.com/henrikrexed/openclaw-observability-plugin/commit/58748393b715abd968fe90a135d650ebdf53bd34))
 
 ## [0.6.1](https://github.com/henrikrexed/openclaw-observability-plugin/compare/v0.6.0...v0.6.1) (2026-06-03)
 

--- a/README.md
+++ b/README.md
@@ -16,26 +16,48 @@ The plugin follows a two-track support model. Pick the plugin track that matches
 | `0.1.x`      | `< 2026.4.21`     | `release/0.1.x`  | Maintenance — security + critical regressions only        | Through **2026-10-21**                         |
 | `0.2.x`      | `>= 2026.4.21`    | `main`           | Superseded by 0.3.x                                      | Replaced by 0.3.x                             |
 | `0.3.x`      | `>= 2026.4.21`    | `main`           | Active — V3 features, log pipeline, bug fixes             | Default going forward                          |
-| `0.6.x`      | `>= 2026.5.13`    | `main`           | Active — Dashboard, diagnostics, token types, telemetry   | Latest release                                 |
+| `0.6.x`      | `>= 2026.5.13`    | `main`           | Superseded by 0.7.x / 0.8.x                              | Replaced by 0.8.x                             |
+| `0.7.x`      | `>= 2026.5.13`    | `main`           | Superseded by 0.8.x                                     | Replaced by 0.8.x                             |
+| `0.8.x`      | `>= 2026.5.13`    | `main`           | Active — GenAI content keys, compaction & subagent spans, tool-error previews | Latest release                                 |
 
 > OpenClaw `2026.4.21` introduced the `before_model_resolve` and `before_prompt_build` hooks and deprecated `before_agent_start`. The `0.2.x` line targets the new hooks; the `0.1.x` line remains on the legacy hook for existing deployments.
 
-## What's New in 0.6.0
+## What's New in 0.8.0
 
-**Released:** 2026-05-13
+**Released:** 2026-07-08
 
 ### Features
-- **Plugin-only dashboard** — Built-in dashboard using collected metrics, spans, and logs for quick observability without external tooling
+- **GenAI content keys for Dynatrace AI Observability** *(ISI-1605, schema 1.4.0)* — Emits the stable OTel GenAI content keys (`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.prompt.prompt_filter_results`, `gen_ai.completion.content_filter_results`) **alongside** the existing `openclaw.content.*` mirrors, sharing the same policy gate and redaction funnel. Adds the `traceloop.span.kind` classifier (`task` on agent-turn spans, `tool` on tool spans) for agent-vs-tool attribution. All content keys are **opt-in** and default **off** — they carry prompt/response bodies (PII). See [Dynatrace → AI Observability](https://henrikrexed.github.io/openclaw-observability-plugin/backends/dynatrace/#ai-observability-gen_ai-content-keys) and [Privacy](https://henrikrexed.github.io/openclaw-observability-plugin/security/privacy/).
+- **Compaction spans & metrics** *(ISI-1628)* — `openclaw.compaction` span plus counter/histogram around `before_compaction` / `after_compaction`.
+- **Subagent trace propagation** *(ISI-1627)* — `subagent_spawned` migration with end-to-end trace propagation into child sessions.
 
-### Improvements
+## What's New in 0.7.0
+
+**Released:** 2026-06-17
+
+### Features
+- **Bounded, redacted tool-error previews** *(ISI-1318)* — Failed tool calls now stamp a redacted, length-capped `openclaw.tool.error_preview` on the tool span so you can triage failures without opening the raw payload. Text is **redacted first, then truncated** to 1024 chars (so a secret straddling the cut can't leak). Gated by the new `captureContent.toolErrorMessages` flag — the one content flag that defaults **on** when `captureContent` is supplied as an object, because error text is operational data, a different privacy class from prompt/response bodies. See [Configuration → `captureContent`](https://henrikrexed.github.io/openclaw-observability-plugin/configuration/#capturecontent-gateway-launch-setting).
+
+## Unreleased (on `main`'s feature branch)
+
+Merged in code review but **not yet in a tagged release**. All changes are **additive** — no keys removed or renamed.
+
+### Tool-span enrichment *(ISI-1629, schema 1.5.0)*
+- Three new tool-span attributes read from the already-subscribed `before_tool_call` hook (no `minOpenClawVersion` bump):
+  - `openclaw.tool.kind` — tool-provider classification (e.g. `builtin`, `mcp`) for tool attribution.
+  - `openclaw.tool.input_kind` — the shape of the tool input (e.g. `command`, `file`, `query`).
+  - `openclaw.tool.derived_paths` — bounded, redacted array of filesystem paths the call will touch, for file blast-radius analysis (capped at 50 entries / 512 chars each; each entry redacted before truncation).
+
+<details>
+<summary>What's New in 0.6.0 (2026-05-13)</summary>
+
+- **Plugin-only dashboard** — Built-in dashboard using collected metrics, spans, and logs for quick observability without external tooling
 - **Token types** — Added `cache_read` and `cache_creation` token types for `gen_ai.client.token.usage` histogram
 - **Diagnostics** — Improved diagnostic event handling with internal module fallback, debug logging, and health metrics wiring
-- **Telemetry** — Prevented double-registration breaking span parent chains
-- **Hooks** — Trace context store persistence across plugin reloads, error logging for `message_received`
+- **Telemetry** — Prevented double-registration breaking span parent chains; trace context store persistence across plugin reloads
+- **Bug fixes** — Dashboard hostname filter and CPU utilization corrections; cache token type defaults for missing data
 
-### Bug Fixes
-- Dashboard hostname filter corrections and CPU utilization metric fixes
-- Cache token type handling with proper defaults for missing data
+</details>
 
 ## Two Approaches to Observability
 

--- a/docs/backends/dynatrace.md
+++ b/docs/backends/dynatrace.md
@@ -127,6 +127,38 @@ fetch spans
 2. Filter: `dt.entity.service = "openclaw-gateway"`
 3. View log records with severity and attributes
 
+## AI Observability (gen_ai content keys)
+
+Dynatrace **AI Observability** renders prompts, responses, and an agent-vs-tool
+call breakdown from OpenTelemetry GenAI semantic-convention attributes. Since
+**0.8.0** (ISI-1605) this plugin emits the keys those views consume:
+
+| Key | Span | Powers |
+|-----|------|--------|
+| `gen_ai.input.messages` | agent turn (`openclaw.agent.turn`) | Prompt / input rendering |
+| `gen_ai.output.messages` | outbound message (`openclaw.message.sent`) | Response rendering |
+| `gen_ai.system_instructions` | agent turn (`openclaw.agent.turn`) | System-prompt rendering |
+| `gen_ai.prompt.prompt_filter_results` | LLM-client span | Azure/OpenAI content-filter payloads |
+| `gen_ai.completion.content_filter_results` | LLM-client span | Azure/OpenAI content-filter payloads |
+| `traceloop.span.kind` | `task` on agent turns, `tool` on tool spans | Agent-vs-tool classification |
+
+- The `gen_ai.*` content keys are **opt-in** and carry prompt/response bodies
+  (**PII by definition**). They emit only when the matching
+  [`captureContent`](../configuration.md#capturecontent-gateway-launch-setting)
+  flag is enabled (`inputMessages`, `outputMessages`, `systemPrompt`) — default
+  off. Each value is redacted, then truncated to 8192 UTF-16 code units. They
+  are emitted alongside the plugin's legacy `openclaw.content.*` mirrors.
+- `traceloop.span.kind` is a Traceloop/OpenLLMetry vendor classifier, **not** a
+  `gen_ai.*` key. It is emitted **unconditionally** (no content gate) so the
+  agent-vs-tool split works even with content capture off.
+- `gen_ai.system_instructions` is the system-prompt **text** — distinct from
+  `gen_ai.provider.name` (provider identity); do not conflate the two.
+
+To light up AI Observability, enable the relevant content flags at gateway
+launch (see [Configuration → `captureContent`](../configuration.md#capturecontent-gateway-launch-setting))
+and review [Privacy](../security/privacy.md) first — content capture ships
+prompt/response bodies to Dynatrace.
+
 ## Example DQL Queries
 
 > The queries below target spans/metrics emitted by **this** plugin. If you only have the built-in `diagnostics-otel` plugin enabled, you'll need to swap `openclaw.llm.*` for `openclaw.tokens` / `openclaw.cost.usd` and adjust the group-by attribute to `openclaw.model`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,15 +291,40 @@ Operators migrating from other OTel SDKs should configure sampling via `plugins.
 The plugin exposes a `captureContent` field in `plugins.entries.otel-observability.config`. It accepts either:
 
 - a single boolean — `true` turns every capture category on, `false` turns every category off (legacy shape, kept for backwards compatibility), or
-- a granular **`ContentCapturePolicy`** object with five independent flags:
+- a granular **`ContentCapturePolicy`** object with six independent flags:
 
 | Flag | Span attribute(s) | What is captured |
 |------|--------------------|-------------------|
-| `inputMessages` | `openclaw.content.input_message` (request span), `openclaw.content.prompt` / `openclaw.content.messages` (agent.turn span) | Inbound user message + the prompt and message history fed to the LLM |
-| `outputMessages` | `openclaw.content.output_message` (message.sent span) | Outbound assistant reply text |
+| `inputMessages` | `gen_ai.input.messages` + `openclaw.content.input_message` (request span), `openclaw.content.prompt` / `openclaw.content.messages` (agent.turn span), `gen_ai.prompt.prompt_filter_results` (LLM-client span) | Inbound user message + the prompt and message history fed to the LLM |
+| `outputMessages` | `gen_ai.output.messages` + `openclaw.content.output_message` (message.sent span), `gen_ai.completion.content_filter_results` (LLM-client span) | Outbound assistant reply text |
 | `toolInputs` | `openclaw.content.tool_input` (execute_tool span) | Full tool-call input arguments (JSON-stringified, capped at 8192 UTF-16 code units) |
 | `toolOutputs` | `openclaw.content.tool_output` (execute_tool span) | Tool-call result text (text parts of the result message, capped at 8192 UTF-16 code units) |
-| `systemPrompt` | `openclaw.content.system_prompt` (agent.turn span) | System prompt text |
+| `toolErrorMessages` | `openclaw.tool.error_preview` (execute_tool span, failure paths only) | Bounded, redacted preview of the tool error text (redacted, then capped at 1024 chars). **Default differs — see the note below** |
+| `systemPrompt` | `gen_ai.system_instructions` + `openclaw.content.system_prompt` (agent.turn span) | System prompt text |
+
+> The stable `gen_ai.*` content keys (ISI-1605, schema `1.4.0`, shipped in
+> **0.8.0**) are emitted **alongside** the legacy `openclaw.content.*` mirrors —
+> both share the same policy gate and the same redact-before-truncate funnel
+> (8192 UTF-16 code units, surrogate-safe). The `gen_ai.*` keys light up
+> **Dynatrace AI Observability** prompt/response rendering; see
+> [Dynatrace → AI Observability](./backends/dynatrace.md#ai-observability-gen_ai-content-keys).
+> `gen_ai.system_instructions` carries the system-prompt **text** and is
+> intentionally distinct from `gen_ai.provider.name` (provider identity).
+
+> ⚠️ **`toolErrorMessages` default is a special case.** Every other flag
+> defaults **off**. `toolErrorMessages` also defaults **off** when
+> `captureContent` is omitted or set to the boolean `false`, but defaults
+> **on** whenever `captureContent` is supplied as an *object* — error text is
+> operational data, a different privacy class from full prompt/response
+> capture. Set `{ "toolErrorMessages": false }` to opt out explicitly.
+>
+> | `captureContent` value | `toolErrorMessages` → `error_preview` |
+> |------------------------|----------------------------------------|
+> | omitted entirely | **off** |
+> | `false` | **off** |
+> | `true` | **on** |
+> | object, e.g. `{ "toolInputs": true }` | **on** (defaults to `true` when not named) |
+> | object `{ "toolErrorMessages": false }` | **off** (explicit opt-out) |
 
 LLM-client spans emitted by Traceloop (`@traceloop/instrumentation-anthropic`, `@traceloop/instrumentation-openai`) still respect the legacy single-boolean Traceloop flag. The plugin derives it from the policy as `inputMessages || outputMessages || systemPrompt` — the three categories that map to prompt/completion text.
 

--- a/docs/telemetry/traces.md
+++ b/docs/telemetry/traces.md
@@ -112,11 +112,29 @@ Created by the `tool_result_persist` hook. Child of the agent turn span.
 | `openclaw.tool.is_synthetic` | boolean | Whether the tool call is synthetic |
 | `openclaw.tool.result_chars` | int | Total characters in result |
 | `openclaw.tool.result_parts` | int | Number of content parts in result |
+| `openclaw.tool.error_preview` | string | **Failure paths only.** Bounded, redacted preview of the tool error text. Gated by `captureContent.toolErrorMessages`; redacted before truncation (1024 chars) |
+| `openclaw.tool.kind` | string | Tool provider classification (e.g. `builtin` vs `mcp`), from `before_tool_call`. *Unreleased — see note below.* |
+| `openclaw.tool.input_kind` | string | Shape of the tool input (e.g. `command`, `file`, `query`), from `before_tool_call`. *Unreleased.* |
+| `openclaw.tool.derived_paths` | string[] | Filesystem paths the call will touch (file blast-radius). Capped at 50 entries / 512 chars each; each entry redacted before truncation. *Unreleased.* |
 | `openclaw.session.key` | string | Session identifier |
 | `openclaw.agent.id` | string | Agent identifier |
 | `gen_ai.tool.name` | string | Tool name (GenAI semconv) |
 | `gen_ai.operation.name` | string | `execute_tool` |
 | `traceloop.span.kind` | string | `tool` — Traceloop/OpenLLMetry marker read by Dynatrace AI Observability |
+
+> `openclaw.tool.error_preview` (ISI-1318) shipped in **0.7.0**. It is written
+> only when a tool call fails. Its `captureContent.toolErrorMessages` gate is
+> the one content flag that defaults **on** when `captureContent` is supplied
+> as an object — error text is operational data, a different privacy class
+> from prompt/response bodies. See
+> [Configuration → `captureContent`](../configuration.md#capturecontent-gateway-launch-setting).
+
+> **Unreleased (ISI-1629):** the tool-span enrichment keys
+> `openclaw.tool.kind`, `openclaw.tool.input_kind`, and
+> `openclaw.tool.derived_paths` are on a feature branch, **not yet merged to
+> `main`** or in a tagged release. They are read from the already-subscribed
+> `before_tool_call` hook — additive only, no `minOpenClawVersion` bump. This
+> reference will move them into the released set once the change lands.
 
 **Status:** `OK` on success, `ERROR` if the tool returned an error.
 


### PR DESCRIPTION
## Docs v0.7.0 / v0.8.0 refresh (ISI-1646)

Brings README + telemetry docs + CHANGELOG current to `main`. Parent: ISI-1642. Authoritative source: **ISI-1645** technical change summary, verified against `src/semconv.ts`, `src/config.ts`, `src/hooks.ts` and the released tags.

### ⚠️ Release-framing note (flagged ambiguity)
The parent title said "v0.0.8" and ISI-1645 framed ISI-1605 + ISI-1629 as "unreleased / expected 0.8.0". Since then **0.8.0 was tagged today (2026-07-08)** and already contains **ISI-1605** (plus ISI-1627, ISI-1628). **ISI-1629 is still on a feature branch, not merged to `main`.** This PR documents the true state:

| Change | Documented as |
|--------|---------------|
| ISI-1318 `error_preview` | **0.7.0** (released) |
| ISI-1605 gen_ai content keys | **0.8.0** (released today) |
| ISI-1629 tool-span enrichment | **Unreleased** (feature branch, not yet on `main`) |

### Changes
- **README.md** — replace stale "What's New in 0.6.0" with 0.8.0 + 0.7.0 sections; add an Unreleased block for ISI-1629; refresh the support matrix (0.7.x/0.8.x).
- **CHANGELOG.md** — add an `[Unreleased]` entry for ISI-1629; dedupe the doubled ISI-1605 (0.8.0) and ISI-1318 (0.7.0) lines.
- **docs/telemetry/traces.md** — document `openclaw.tool.error_preview` (0.7.0) and the ISI-1629 enrichment keys (marked unreleased).
- **docs/configuration.md** — document the 6th `captureContent` flag `toolErrorMessages` with its object-only default-on behavior table, the `gen_ai.*` mirrors, and the size caps.
- **docs/backends/dynatrace.md** — add an **AI Observability** section covering the `gen_ai.*` content keys and the `traceloop.span.kind` classifier.

### Verification
- `mkdocs build --strict` — the only 2 warnings are **pre-existing on `main`** (`getting-started.md → ../README.md#hooks…` and `traces.md:50 → ../../CHANGELOG.md`); all new cross-page anchors resolve cleanly.
- Scope respected: **no `OC_COMPACTION_*` env keys documented** (those belong to ISI-1628).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
