### PR TITLE
fix(ISI-1653): re-parent lifecycle spans into the request/session trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Merged in code review but not yet in a tagged release. Additive — no keys remo
 
 * **ISI-1629:** tool-span enrichment — `openclaw.tool.kind`, `openclaw.tool.input_kind`, and bounded/redacted `openclaw.tool.derived_paths`, read from the already-subscribed `before_tool_call` hook (tool attribution + file blast-radius analysis)
 
+### Bug Fixes
+
+* **ISI-1653:** lifecycle event spans (`openclaw.message.sent`, `openclaw.cron.changed`, `openclaw.dispatch.prepare`) no longer orphan into their own single-span traces. A shared `resolveLifecycleParentContext` walks all store tiers (active → legacy → retained-recent-request → session → gateway) so these spans nest into the request/session trace they belong to, collapsing the previous "1 request → 3-4 traces" fan-out into one trace. A trailing `message_sent` that fires *after* `agent_end` tears down the live context now re-attaches via a bounded, TTL'd (60s) retained request context. The resolved anchor is stamped on each span as `openclaw.trace.parent_source` for diagnosability.
+
 ## [0.8.0](https://github.com/henrikrexed/openclaw-observability-plugin/compare/v0.7.0...v0.8.0) (2026-07-08)
 
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -143,6 +143,57 @@ const store: TraceContextStore =
 (globalThis as any)[GLOBAL_STORE_KEY] = store;
 
 /**
+ * Resolve the best available parent context for a lifecycle-event span
+ * (`message_sent`, `cron_changed`, `before_dispatch`, …) so it nests into the
+ * live request/session trace instead of orphaning into its own single-span
+ * trace (ISI-1653).
+ *
+ * These events do NOT run inside an activated OTel context — the OpenClaw hook
+ * dispatcher never wraps handlers in `context.with(...)` — so `context.active()`
+ * is always the empty root. The ONLY way these spans get a parent is an explicit
+ * store lookup. When that lookup misses (the event fires before the request
+ * context exists, or after `agent_end` tore it down), the span silently becomes
+ * a disconnected root.
+ *
+ * Resolution order, strongest (most specific, live) first:
+ *   1. live active context   — agent-turn span, else request root
+ *   2. tiered legacy resolve — turn/request tiers of the store
+ *   3. retained recent request — the just-ended request's trace, kept briefly
+ *      so a trailing `message_sent` / `cron_changed` firing AFTER `agent_end`
+ *      still lands in that request's trace (see TraceContextStore retention)
+ *   4. live session span     — long-lived per-conversation anchor
+ *   5. gateway span          — process-lifetime anchor (last resort)
+ *
+ * `context` is undefined only when the store holds nothing at all (very early
+ * startup); callers then fall back to `context.active()` and start a root span
+ * exactly as before. `source` is stamped on the span as
+ * `openclaw.trace.parent_source` for diagnosability.
+ */
+function resolveLifecycleParentContext(
+  store: TraceContextStore,
+  sessionKey: string,
+): { context?: Context; source: string } {
+  const active = store.getActiveContext(sessionKey);
+  if (active?.agentContext) return { context: active.agentContext, source: "agent" };
+  if (active?.rootContext) return { context: active.rootContext, source: "request" };
+
+  const legacy = store.resolveLegacyContext(sessionKey);
+  if (legacy?.agentContext) return { context: legacy.agentContext, source: "turn" };
+  if (legacy?.rootContext) return { context: legacy.rootContext, source: "request" };
+
+  const recent = store.getRecentRequestContext(sessionKey);
+  if (recent) return { context: recent, source: "recent_request" };
+
+  const session = store.getSession(sessionKey)?.context;
+  if (session) return { context: session, source: "session" };
+
+  const gateway = store.getGateway()?.context;
+  if (gateway) return { context: gateway, source: "gateway" };
+
+  return { context: undefined, source: "none" };
+}
+
+/**
  * Register all plugin hooks on the OpenClaw plugin API.
  *
  * Hooks are registered during the synchronous `register()` phase using a
@@ -1206,8 +1257,12 @@ export function registerHooks(
         if (!sessionCtx) {
           logger.warn(`[otel] DIAG before_dispatch: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount}, eventKeys=${Object.keys(event || {}).join(',')}, ctxKeys=${Object.keys(ctx || {}).join(',')}`);
         }
-        const parentContext =
-          sessionCtx?.agentContext || sessionCtx?.rootContext || context.active();
+        // ISI-1653: resolve a live parent through all store tiers so the
+        // dispatch span never orphans into its own trace when the direct
+        // activeContext lookup misses.
+        const { context: resolvedParent, source: parentSource } =
+          resolveLifecycleParentContext(store, sessionKey);
+        const parentContext = resolvedParent ?? context.active();
 
         const span = tracer.startSpan(
           "openclaw.dispatch.prepare",
@@ -1222,6 +1277,7 @@ export function registerHooks(
               ...codeAttrs("before_dispatch"),
               "openclaw.session.key": sessionKey,
               "openclaw.agent.id": agentId,
+              "openclaw.trace.parent_source": parentSource,
             },
           },
           parentContext
@@ -1722,12 +1778,17 @@ export function registerHooks(
         const charCount =
           typeof messageText === "string" ? messageText.length : 0;
 
-        const sessionCtx = store.getActiveContext(sessionKey);
-        if (!sessionCtx) {
+        // ISI-1653: an outbound `message_sent` fires when the reply is
+        // delivered to the channel, which routinely happens AFTER `agent_end`
+        // has already torn down the live request context. Resolve through all
+        // store tiers — including the retained recent-request trace — so the
+        // reply span nests into the request it answers instead of orphaning.
+        if (!store.getActiveContext(sessionKey)) {
           logger.warn(`[otel] DIAG message_sent: NO sessionCtx for sessionKey=${sessionKey}, storeSize=${store.activeContextCount}, eventKeys=${Object.keys(event || {}).join(',')}, ctxKeys=${Object.keys(ctx || {}).join(',')}`);
         }
-        const parentContext =
-          sessionCtx?.rootContext || sessionCtx?.agentContext || context.active();
+        const { context: resolvedParent, source: parentSource } =
+          resolveLifecycleParentContext(store, sessionKey);
+        const parentContext = resolvedParent ?? context.active();
 
         const span = tracer.startSpan(
           "openclaw.message.sent",
@@ -1744,6 +1805,7 @@ export function registerHooks(
               [GEN_AI_CONVERSATION_ID]: sessionKey,
               // code.*
               ...codeAttrs("message_sent"),
+              "openclaw.trace.parent_source": parentSource,
             },
           },
           parentContext
@@ -2736,9 +2798,12 @@ export function registerHooks(
         const sessionKey = ctx?.sessionKey || event?.sessionKey || "unknown";
         const provider = event?.provider || ctx?.provider || "unknown";
 
-        const parentContext = store.getActiveContext(sessionKey)?.agentContext
-          || store.getActiveContext(sessionKey)?.rootContext
-          || context.active();
+        // ISI-1653: nest the cron-change span into the live request/session
+        // trace via all store tiers instead of starting a fresh root when the
+        // direct activeContext lookup misses.
+        const { context: resolvedParent, source: parentSource } =
+          resolveLifecycleParentContext(store, sessionKey);
+        const parentContext = resolvedParent ?? context.active();
 
         const span = tracer.startSpan(
           "openclaw.cron.changed",
@@ -2752,6 +2817,7 @@ export function registerHooks(
               ...codeAttrs("cron_changed"),
               "openclaw.session.key": sessionKey,
               "openclaw.agent.id": agentId,
+              "openclaw.trace.parent_source": parentSource,
             },
           },
           parentContext

--- a/src/trace-context-store.ts
+++ b/src/trace-context-store.ts
@@ -93,6 +93,20 @@ export class TraceContextStore {
   private activeRequestKey = new Map<string, string>();
   private activeTurnKey = new Map<string, string>();
 
+  // ── Retained recent request contexts (ISI-1653) ───────────────────
+  // Trailing lifecycle events — an outbound `message_sent` (channel
+  // delivery) or a late `cron_changed` — frequently fire AFTER `agent_end`
+  // has already run `cleanupSession`, so the live activeContext is gone and
+  // the span would start a fresh root, orphaning into its own single-span
+  // trace. We retain the just-ended request's root Context briefly, keyed by
+  // sessionKey, so those trailing spans still nest into the SAME trace as the
+  // request they belong to. Bounded by size + TTL: the size cap prevents
+  // unbounded growth, and the TTL prevents a much-later event from being
+  // cross-linked into a stale, unrelated trace.
+  private recentRequests = new Map<string, { rootContext: Context; retainedAt: number }>();
+  private static readonly RECENT_MAX = 256;
+  private static readonly RECENT_TTL_MS = 60_000;
+
   // ── Gateway ───────────────────────────────────────────────────────
 
   setGateway(ctx: GatewayContext): void {
@@ -288,6 +302,39 @@ export class TraceContextStore {
     return undefined;
   }
 
+  // ── Retained recent request context (ISI-1653) ────────────────────
+
+  /**
+   * Retain a request's root Context after it ends so a trailing lifecycle
+   * event (outbound `message_sent`, late `cron_changed`) that fires after
+   * teardown can still nest into the same trace. Evicts the oldest entry
+   * when the size cap is reached (the Map is insertion-ordered).
+   */
+  retainRecentRequest(sessionKey: string, rootContext: Context): void {
+    // Re-insert to move this key to the newest position.
+    this.recentRequests.delete(sessionKey);
+    if (this.recentRequests.size >= TraceContextStore.RECENT_MAX) {
+      const oldest = this.recentRequests.keys().next().value;
+      if (oldest !== undefined) this.recentRequests.delete(oldest);
+    }
+    this.recentRequests.set(sessionKey, { rootContext, retainedAt: Date.now() });
+  }
+
+  /**
+   * Return the retained root Context for a recently-ended request, or
+   * undefined when none exists or the retained entry has aged past the TTL
+   * (in which case it is evicted so it can never parent a stale trace).
+   */
+  getRecentRequestContext(sessionKey: string): Context | undefined {
+    const retained = this.recentRequests.get(sessionKey);
+    if (!retained) return undefined;
+    if (Date.now() - retained.retainedAt > TraceContextStore.RECENT_TTL_MS) {
+      this.recentRequests.delete(sessionKey);
+      return undefined;
+    }
+    return retained.rootContext;
+  }
+
   resolveParentContext(sessionKey: string): Context | undefined {
     const parentKey = this.subAgentLinks.get(sessionKey);
     if (!parentKey) return undefined;
@@ -324,6 +371,15 @@ export class TraceContextStore {
   cleanupSession(sessionKey: string): void {
     const rk = this.activeRequestKey.get(sessionKey);
     const tk = this.activeTurnKey.get(sessionKey);
+
+    // ISI-1653: retain the request's root trace briefly BEFORE teardown so a
+    // trailing `message_sent` / `cron_changed` still nests into this trace
+    // instead of orphaning. Prefer the request tier, fall back to the legacy
+    // activeContext root.
+    const retainRoot =
+      (rk ? this.requests.get(rk)?.rootContext : undefined) ??
+      this.activeContexts.get(sessionKey)?.rootContext;
+    if (retainRoot) this.retainRecentRequest(sessionKey, retainRoot);
 
     if (tk) {
       const turn = this.agentTurns.get(tk);
@@ -428,6 +484,7 @@ export class TraceContextStore {
     this.subAgentLinks.clear();
     this.activeRequestKey.clear();
     this.activeTurnKey.clear();
+    this.recentRequests.clear();
   }
 
   // ── Diagnostics ───────────────────────────────────────────────────

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -3632,3 +3632,103 @@ describe("compaction spans + metrics (ISI-1628)", () => {
     expect(telemetry.counters.compactionCount.add).not.toHaveBeenCalled();
   });
 });
+
+// ── Lifecycle span re-parenting (ISI-1653) ──────────────────────────────
+// Regression coverage for the "1 request → 3-4 traces" bug: lifecycle event
+// spans (message.sent, cron.changed, dispatch.prepare) must nest into the
+// live request/session trace instead of starting fresh disconnected roots.
+describe("lifecycle span re-parenting (ISI-1653)", () => {
+  let stopHooks: () => void;
+
+  it("message.sent nests into the retained request trace after agent_end tore it down", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const messageReceived = typedHooks.get("message_received")!;
+    const agentEnd = typedHooks.get("agent_end")!;
+    const messageSent = typedHooks.get("message_sent")!;
+
+    // 1) inbound message opens the request root span
+    messageReceived({ sessionKey: "s1", text: "hi" }, {});
+    const rootSpan = spans.find(
+      (s) => s.spanName === "openclaw.request" && s.attrs["openclaw.session.key"] === "s1",
+    )!;
+    expect(rootSpan).toBeDefined();
+
+    // 2) agent_end ends + cleans up the live context (retaining the trace)
+    agentEnd({ sessionKey: "s1", success: true, messages: [] }, { sessionKey: "s1", agentId: "a" });
+
+    // 3) the channel delivers the reply AFTER teardown
+    messageSent({ sessionKey: "s1", channel: "whatsapp", text: "reply" }, {});
+
+    const sent = spans.find((s) => s.spanName === "openclaw.message.sent")!;
+    expect(sent).toBeDefined();
+    // Nested into the SAME trace as the request it answers — not a fresh root.
+    expect(trace.getSpanContext(sent.parentContext as any)?.spanId).toBe(rootSpan.id);
+    expect(sent.attrs["openclaw.trace.parent_source"]).toBe("recent_request");
+
+    stopHooks();
+  });
+
+  it("cron.changed falls back to the live session span when there is no active request", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    const sessionStart = typedHooks.get("session_start")!;
+    const cronChanged = typedHooks.get("cron_changed")!;
+
+    sessionStart({ sessionKey: "s2", agentId: "a" }, {});
+    const sessionSpan = spans.find((s) => s.spanName === "openclaw.session")!;
+    expect(sessionSpan).toBeDefined();
+
+    // No request/turn context is live — only the session span exists.
+    cronChanged({ jobName: "nightly", action: "created" }, { sessionKey: "s2" });
+
+    const cronSpan = spans.find((s) => s.spanName === "openclaw.cron.changed")!;
+    expect(cronSpan).toBeDefined();
+    expect(trace.getSpanContext(cronSpan.parentContext as any)?.spanId).toBe(sessionSpan.id);
+    expect(cronSpan.attrs["openclaw.trace.parent_source"]).toBe("session");
+
+    stopHooks();
+  });
+
+  it("message.sent stays a root only when the store holds nothing at all", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    // No prior message_received / session_start for this session.
+    typedHooks.get("message_sent")!({ sessionKey: "cold", channel: "cli", text: "hi" }, {});
+
+    const sent = spans.find((s) => s.spanName === "openclaw.message.sent")!;
+    expect(sent).toBeDefined();
+    expect(trace.getSpanContext(sent.parentContext as any)).toBeUndefined();
+    expect(sent.attrs["openclaw.trace.parent_source"]).toBe("none");
+
+    stopHooks();
+  });
+
+  it("dispatch.prepare still parents to the agent turn span (regression)", () => {
+    const { api, typedHooks } = createStubApi();
+    const { telemetry, spans } = createTelemetry();
+    stopHooks = registerHooks(api, () => telemetry, config);
+
+    typedHooks.get("before_model_resolve")!({}, { agentId: "a1", sessionKey: "s3" });
+    const turnSpan = spans.find((s) => s.spanName === "openclaw.agent.turn")!;
+    expect(turnSpan).toBeDefined();
+
+    typedHooks.get("before_dispatch")!(
+      { sessionKey: "s3", model: "gpt-4o", provider: "openai" },
+      { sessionKey: "s3" },
+    );
+
+    const dispatchSpan = spans.find((s) => s.spanName === "openclaw.dispatch.prepare")!;
+    expect(dispatchSpan).toBeDefined();
+    expect(trace.getSpanContext(dispatchSpan.parentContext as any)?.spanId).toBe(turnSpan.id);
+    expect(dispatchSpan.attrs["openclaw.trace.parent_source"]).toBe("agent");
+
+    stopHooks();
+  });
+});

--- a/tests/trace-context-store.test.ts
+++ b/tests/trace-context-store.test.ts
@@ -485,4 +485,53 @@ describe("TraceContextStore", () => {
       expect(stats.subAgentLinks).toBe(1);
     });
   });
+
+  describe("retained recent request context (ISI-1653)", () => {
+    it("returns a retained root context within the TTL window", () => {
+      const ctx = createContextSpy();
+      store.retainRecentRequest("s1", ctx);
+      expect(store.getRecentRequestContext("s1")).toBe(ctx);
+    });
+
+    it("returns undefined for a session with nothing retained", () => {
+      expect(store.getRecentRequestContext("missing")).toBeUndefined();
+    });
+
+    it("evicts and returns undefined once the entry ages past the TTL", () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(0);
+        const ctx = createContextSpy();
+        store.retainRecentRequest("s1", ctx);
+        // Just inside the 60s TTL — still resolvable.
+        vi.setSystemTime(59_000);
+        expect(store.getRecentRequestContext("s1")).toBe(ctx);
+        // Past the TTL — evicted.
+        vi.setSystemTime(61_000);
+        expect(store.getRecentRequestContext("s1")).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("cleanupSession retains the request root so a trailing event can nest", () => {
+      const rootCtx = createContextSpy();
+      store.setActiveContext("s1", {
+        rootSpan: createSpanSpy("openclaw.request"),
+        rootContext: rootCtx,
+        startTime: Date.now(),
+      });
+      store.cleanupSession("s1");
+      // Live context is gone…
+      expect(store.getActiveContext("s1")).toBeUndefined();
+      // …but the trace is retained for trailing lifecycle spans.
+      expect(store.getRecentRequestContext("s1")).toBe(rootCtx);
+    });
+
+    it("clear() drops retained contexts", () => {
+      store.retainRecentRequest("s1", createContextSpy());
+      store.clear();
+      expect(store.getRecentRequestContext("s1")).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## ISI-1653: lifecycle event spans orphaned — 1 request → 3-4 traces

### Root cause
`openclaw.message.sent`, `openclaw.cron.changed`, and `openclaw.dispatch.prepare` are created off an OTel context that must come from an **explicit store lookup** — the OpenClaw hook dispatcher never wraps handlers in `context.with(...)`, so `context.active()` is always the empty root. When the direct `store.getActiveContext(sessionKey)` lookup missed, each span silently became a **disconnected trace root**:

- `message.sent` fires when the reply is delivered to the channel — routinely **after `agent_end`** already ran `cleanupSession()`, so the live context was gone.
- `cron.changed` fires when there is no active request/turn context.
- `dispatch.prepare` orphaned whenever the direct lookup missed (main already had a `DIAG ... NO sessionCtx` warn for exactly this).

### Fix
- New shared `resolveLifecycleParentContext(store, sessionKey)` walks every store tier, strongest first: **active → legacy(turn/request) → retained-recent-request → session → gateway**. Used by all three hooks.
- `TraceContextStore` now retains a just-ended request's root `Context` in `cleanupSession()`, bounded (256 entries) + TTL'd (60s), so a trailing `message_sent` re-attaches to the **same trace as the request it answers** instead of orphaning. TTL prevents cross-linking a stale, unrelated trace.
- Each span is stamped with `openclaw.trace.parent_source` (`agent`/`request`/`recent_request`/`session`/`gateway`/`none`) for diagnosability. Falls back to a root span **only** when the store holds nothing at all.

### Tests
+9 tests (5 store retention/TTL/cleanup, 4 hook re-parenting incl. a regression that `dispatch.prepare` still nests under the agent turn). Full suite **304 pass**, `tsc --noEmit` clean.

### Not in scope (follow-up)
Secondary issue in the ticket — auto-instrumented GenAI `chat <model>` spans parenting to `agent.turn` instead of `llm.call` — is **not** addressed here; it requires activating the OTel context around the SDK call (`context.with`) and runtime verification against OpenLLMetry. Recommend a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
